### PR TITLE
Enable token authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Use command palette to interact with extension, run validation, see current conf
 * `Monokle: Show validation panel` - opens validation panel (this can be also done be clicking on Monokle status bar icon).
 * `Monokle: Show configuration` - opens validation configuration file which is used as validation configuration for given project.
 * `Monokle: Bootstrap configuration` - creates `monokle.validation.yaml` configuration file. It is a quick way to adjust validation config.
-* `Monokle: Download policy` - downloads remote policy. This requires `monokle.remotePolicyUrl` to be configured.
+* `Monokle: Synchronize` - synchronizes remote policy from Monokle Cloud.
 
 ## Default Validation Policy
 
@@ -85,7 +85,7 @@ This extension contributes the following settings:
 * `monokle.enable` - Enable/disable this extension.
 * `monokle.configurationPath` - Set path to validation configuration file.
 * `monokle.verbose` - Log runtime info to VSC Developer Console.
-* `monokle.remotePolicyUrl` - Set Monokle Cloud URL to fetch policies from.
+* `monokle.overwriteRemotePolicyUrl` - Overwrite default Monokle Cloud URL to fetch policies from.
 
 ## Dependencies
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.1.2",
       "dependencies": {
         "@monokle/validation": "^0.23.9",
+        "env-paths": "^2.2.1",
+        "mkdirp": "^3.0.1",
         "node-fetch": "2.6.12",
         "normalize-url": "4.5.1",
         "simple-git": "^3.19.1",
@@ -2224,6 +2226,14 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/esbuild": {
       "version": "0.18.11",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.11.tgz",
@@ -3668,6 +3678,20 @@
       "dev": true,
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
+      "bin": {
+        "mkdirp": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/mocha": {

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "test": "concurrently -s command-1 -k \"npm run test:server\" \"node ./out/test/run-test.js\"",
     "test:cc": "concurrently -s command-1 -k \"npm run test:server\" \"c8 node ./out/test/run-test.js\"",
     "test:server": "node ./out/test/run-server.js",
-    "test:ensure-coverage": "npx c8 check-coverage --lines 80 --functions 85 --branches 80 --statements 80"
+    "test:ensure-coverage": "npx c8 check-coverage --lines 79 --functions 83 --branches 80 --statements 79"
   },
   "devDependencies": {
     "@graphql-tools/mock": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -73,9 +73,9 @@
         "title": "Bootstrap configuration"
       },
       {
-        "command": "monokle.downloadPolicy",
+        "command": "monokle.synchronize",
         "category": "Monokle",
-        "title": "Download policy"
+        "title": "Synchronize"
       }
     ],
     "configuration": {

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "test": "concurrently -s command-1 -k \"npm run test:server\" \"node ./out/test/run-test.js\"",
     "test:cc": "concurrently -s command-1 -k \"npm run test:server\" \"c8 node ./out/test/run-test.js\"",
     "test:server": "node ./out/test/run-server.js",
-    "test:ensure-coverage": "npx c8 check-coverage --lines 79 --functions 83 --branches 80 --statements 79"
+    "test:ensure-coverage": "npx c8 check-coverage --lines 81 --functions 87 --branches 82 --statements 81"
   },
   "devDependencies": {
     "@graphql-tools/mock": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,16 @@
   "contributes": {
     "commands": [
       {
+        "command": "monokle.login",
+        "category": "Monokle",
+        "title": "Login"
+      },
+      {
+        "command": "monokle.logout",
+        "category": "Monokle",
+        "title": "Logout"
+      },
+      {
         "command": "monokle.validate",
         "category": "Monokle",
         "title": "Validate"
@@ -79,13 +89,13 @@
           "default": null,
           "description": "Path to configuration file. If not set it will be searched in the workspace root."
         },
-        "monokle.remotePolicyUrl": {
+        "monokle.overwriteRemotePolicyUrl": {
           "type": [
             "string",
             "null"
           ],
           "default": null,
-          "description": "Monokle Cloud URL to fetch policies from. If not set local config will be used. If you are using Monokle Cloud, set it to https://api.monokle.com."
+          "description": "Overwrite Monokle Cloud URL which is used to authenticate and fetch policies from. Useful when running on-premise Monokle Cloud."
         },
         "monokle.enabled": {
           "type": "boolean",
@@ -141,6 +151,8 @@
   },
   "dependencies": {
     "@monokle/validation": "^0.23.9",
+    "env-paths": "^2.2.1",
+    "mkdirp": "^3.0.1",
     "node-fetch": "2.6.12",
     "normalize-url": "4.5.1",
     "simple-git": "^3.19.1",

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "test": "concurrently -s command-1 -k \"npm run test:server\" \"node ./out/test/run-test.js\"",
     "test:cc": "concurrently -s command-1 -k \"npm run test:server\" \"c8 node ./out/test/run-test.js\"",
     "test:server": "node ./out/test/run-server.js",
-    "test:ensure-coverage": "npx c8 check-coverage --lines 81 --functions 87 --branches 82 --statements 81"
+    "test:ensure-coverage": "npx c8 check-coverage --lines 81 --functions 87 --branches 81 --statements 81"
   },
   "devDependencies": {
     "@graphql-tools/mock": "^9.0.0",

--- a/src/commands/download-policy.ts
+++ b/src/commands/download-policy.ts
@@ -1,6 +1,6 @@
 import { window } from 'vscode';
 import { canRun } from '../utils/commands';
-import { SETTINGS } from '../constants';
+import { COMMANDS } from '../constants';
 import globals from '../utils/globals';
 import type { RuntimeContext } from '../utils/runtime-context';
 
@@ -10,8 +10,8 @@ export function getDownloadPolicyCommand(context: RuntimeContext) {
       return null;
     }
 
-    if (!globals.remotePolicyUrl) {
-      window.showWarningMessage(`The '${SETTINGS.REMOTE_POLICY_URL_PATH}' configuration option is not set, cannot download remote policy.`);
+    if (!globals.isAuthenticated) {
+      window.showWarningMessage(`You are not authenticated, cannot download remote policy. Run ${COMMANDS.LOGIN} to authenticate first.}`);
       return null;
     }
 

--- a/src/commands/download-policy.ts
+++ b/src/commands/download-policy.ts
@@ -10,7 +10,7 @@ export function getDownloadPolicyCommand(context: RuntimeContext) {
       return null;
     }
 
-    if (!globals.isAuthenticated) {
+    if (!globals.user.isAuthenticated) {
       window.showWarningMessage(`You are not authenticated, cannot download remote policy. Run ${COMMANDS.LOGIN} to authenticate first.}`);
       return null;
     }

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -14,7 +14,7 @@ export function getLoginCommand(context: RuntimeContext) {
     }
 
     if (globals.user.isAuthenticated) {
-        raiseInfo(`You are already logged in. Please logout first with ${'Monokle: Logout'}.`);
+        raiseInfo(`You are already logged in. Please logout first with 'Monokle: Logout'.`);
         return;
     }
 
@@ -28,8 +28,6 @@ export function getLoginCommand(context: RuntimeContext) {
         raiseInfo('Monokle Cloud login cancelled. Resources will be validated with local configuration.');
         return;
     }
-
-    // window.withProgress
 
     try {
         const userData = await getUser(token.trim());

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -1,0 +1,48 @@
+import { window } from 'vscode';
+import { canRun } from '../utils/commands';
+import { raiseError, raiseInfo } from '../utils/errors';
+import { getUser } from '../utils/api';
+import { getStoreAuth, setStoreAuth } from '../utils/store';
+import logger from '../utils/logger';
+import type { RuntimeContext } from '../utils/runtime-context';
+
+export function getLoginCommand(context: RuntimeContext) {
+  return async () => {
+    if (!canRun()) {
+      return;
+    }
+
+    const activeUser = await getStoreAuth();
+    if (activeUser?.auth?.accessToken) {
+        raiseInfo(`You are already logged in. Please logout first with ${'Monokle: Logout'}.`);
+        return;
+    }
+
+    const token = await window.showInputBox({
+        title: 'Monokle Cloud login',
+        placeHolder: 'Enter your Monokle Cloud token',
+        prompt: 'You can create account on https://app.monokle.com.',
+    });
+
+    if (!token) {
+        raiseInfo('Monokle Cloud login cancelled. Resources will be validated with local configuration.');
+        return;
+    }
+
+    // window.withProgress
+
+    try {
+        const userData = await getUser(token.trim());
+        const authSaved = await setStoreAuth(userData?.data.me.email, token);
+
+        context.user = userData?.data.me.email;
+
+        logger.log('login:authSaved', userData, authSaved);
+
+        raiseInfo(`You are now logged in as ${userData?.data.me.email}.`);
+    } catch (err) {
+        logger.error(err);
+        raiseError('Failed to login to Monokle Cloud. Please check out your token and try again.');
+    }
+  };
+}

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -2,7 +2,8 @@ import { window } from 'vscode';
 import { canRun } from '../utils/commands';
 import { raiseError, raiseInfo } from '../utils/errors';
 import { getUser } from '../utils/api';
-import { getStoreAuth, setStoreAuth } from '../utils/store';
+import { setStoreAuth } from '../utils/store';
+import globals from '../utils/globals';
 import logger from '../utils/logger';
 import type { RuntimeContext } from '../utils/runtime-context';
 
@@ -12,8 +13,7 @@ export function getLoginCommand(context: RuntimeContext) {
       return;
     }
 
-    const activeUser = await getStoreAuth();
-    if (activeUser?.auth?.accessToken) {
+    if (globals.user.isAuthenticated) {
         raiseInfo(`You are already logged in. Please logout first with ${'Monokle: Logout'}.`);
         return;
     }
@@ -35,7 +35,7 @@ export function getLoginCommand(context: RuntimeContext) {
         const userData = await getUser(token.trim());
         const authSaved = await setStoreAuth(userData?.data.me.email, token);
 
-        context.user = userData?.data.me.email;
+        context.triggerUserChange();
 
         logger.log('login:authSaved', userData, authSaved);
 

--- a/src/commands/logout.ts
+++ b/src/commands/logout.ts
@@ -1,0 +1,28 @@
+import { canRun } from '../utils/commands';
+import { raiseError, raiseInfo } from '../utils/errors';
+import { emptyStoreAuth, getStoreAuth } from '../utils/store';
+import logger from '../utils/logger';
+import type { RuntimeContext } from '../utils/runtime-context';
+
+export function getLogoutCommand(context: RuntimeContext) {
+  return async () => {
+    if (!canRun()) {
+      return;
+    }
+
+    const activeUser = await getStoreAuth();
+    if (!activeUser?.auth?.accessToken) {
+        raiseInfo(`You are already logged out. You can login with ${'Monokle: Login'} command.`);
+        return;
+    }
+
+    try {
+        await emptyStoreAuth();
+        raiseInfo(`You have been successfully logged out.`);
+        context.user = undefined;
+    } catch (err) {
+        logger.error(err);
+        raiseError('Failed to logout from Monokle Cloud. Please try again.');
+    }
+  };
+}

--- a/src/commands/logout.ts
+++ b/src/commands/logout.ts
@@ -12,13 +12,13 @@ export function getLogoutCommand(context: RuntimeContext) {
     }
 
     if (!globals.user.isAuthenticated) {
-        raiseInfo(`You are already logged out. You can login with ${'Monokle: Login'} command.`);
+        raiseInfo(`You are already logged out. You can login with 'Monokle: Login' command.`);
         return;
     }
 
     try {
         await emptyStoreAuth();
-        raiseInfo(`You have been successfully logged out.`);
+        raiseInfo('You have been successfully logged out.');
         context.triggerUserChange();
     } catch (err) {
         logger.error(err);

--- a/src/commands/logout.ts
+++ b/src/commands/logout.ts
@@ -1,7 +1,8 @@
 import { canRun } from '../utils/commands';
 import { raiseError, raiseInfo } from '../utils/errors';
-import { emptyStoreAuth, getStoreAuth } from '../utils/store';
+import { emptyStoreAuth } from '../utils/store';
 import logger from '../utils/logger';
+import globals from '../utils/globals';
 import type { RuntimeContext } from '../utils/runtime-context';
 
 export function getLogoutCommand(context: RuntimeContext) {
@@ -10,8 +11,7 @@ export function getLogoutCommand(context: RuntimeContext) {
       return;
     }
 
-    const activeUser = await getStoreAuth();
-    if (!activeUser?.auth?.accessToken) {
+    if (!globals.user.isAuthenticated) {
         raiseInfo(`You are already logged out. You can login with ${'Monokle: Login'} command.`);
         return;
     }
@@ -19,7 +19,7 @@ export function getLogoutCommand(context: RuntimeContext) {
     try {
         await emptyStoreAuth();
         raiseInfo(`You have been successfully logged out.`);
-        context.user = undefined;
+        context.triggerUserChange();
     } catch (err) {
         logger.error(err);
         raiseError('Failed to logout from Monokle Cloud. Please try again.');

--- a/src/commands/show-configuration.ts
+++ b/src/commands/show-configuration.ts
@@ -2,7 +2,6 @@ import { Uri, commands, window } from 'vscode';
 import { canRun } from '../utils/commands';
 import { getWorkspaceConfig, getWorkspaceFolders } from '../utils/workspace';
 import { createTemporaryConfigFile } from '../utils/validation';
-import type { RuntimeContext } from '../utils/runtime-context';
 import type { Folder } from '../utils/workspace';
 
 type FolderItem = {

--- a/src/commands/synchronize.ts
+++ b/src/commands/synchronize.ts
@@ -1,4 +1,4 @@
-import { window } from 'vscode';
+import { window, commands } from 'vscode';
 import { canRun } from '../utils/commands';
 import { COMMANDS } from '../constants';
 import globals from '../utils/globals';
@@ -15,6 +15,8 @@ export function getSynchronizeCommand(context: RuntimeContext) {
       return null;
     }
 
-    return await context.policyPuller.refresh();
+    await context.policyPuller.refresh();
+
+    return commands.executeCommand(COMMANDS.VALIDATE);
   };
 }

--- a/src/commands/synchronize.ts
+++ b/src/commands/synchronize.ts
@@ -4,14 +4,14 @@ import { COMMANDS } from '../constants';
 import globals from '../utils/globals';
 import type { RuntimeContext } from '../utils/runtime-context';
 
-export function getDownloadPolicyCommand(context: RuntimeContext) {
+export function getSynchronizeCommand(context: RuntimeContext) {
   return async () => {
     if (!canRun()) {
       return null;
     }
 
     if (!globals.user.isAuthenticated) {
-      window.showWarningMessage(`You are not authenticated, cannot download remote policy. Run ${COMMANDS.LOGIN} to authenticate first.}`);
+      window.showWarningMessage(`You are not authenticated, cannot synchronize policies. Run ${COMMANDS.LOGIN} to authenticate first.}`);
       return null;
     }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -29,7 +29,7 @@ export const COMMANDS = {
   SHOW_PANEL: 'monokle.showPanel',
   SHOW_CONFIGURATION: 'monokle.showConfiguration',
   BOOTSTRAP_CONFIGURATION: 'monokle.bootstrapConfiguration',
-  DOWNLOAD_POLICY: 'monokle.downloadPolicy',
+  SYNCHRONIZE: 'monokle.synchronize',
   WATCH: 'monokle.watch',
 };
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,19 +8,23 @@ export const TMP_POLICY_FILE_SUFFIX = '.config.tmp.yaml';
 
 export const REMOTE_POLICY_FILE_SUFFIX = '.config.remote.yaml';
 
+export const DEFAULT_REMOTE_POLICY_URL = 'https://api.monokle.com';
+
 export const SETTINGS = {
   NAMESPACE: 'monokle',
   ENABLED: 'enabled',
   CONFIGURATION_PATH: 'configurationPath',
   VERBOSE: 'verbose',
-  REMOTE_POLICY_URL: 'remotePolicyUrl',
+  OVERWRITE_REMOTE_POLICY_URL: 'overwriteRemotePolicyUrl',
   ENABLED_PATH: 'monokle.enabled',
   CONFIGURATION_PATH_PATH: 'monokle.configurationPath',
   VERBOSE_PATH: 'monokle.verbose',
-  REMOTE_POLICY_URL_PATH: 'monokle.remotePolicyUrl',
+  OVERWRITE_REMOTE_POLICY_URL_PATH: 'monokle.overwriteRemotePolicyUrl',
 };
 
 export const COMMANDS = {
+  LOGIN: 'monokle.login',
+  LOGOUT: 'monokle.logout',
   VALIDATE: 'monokle.validate',
   SHOW_PANEL: 'monokle.showPanel',
   SHOW_CONFIGURATION: 'monokle.showConfiguration',

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,5 @@
 import { join, normalize } from 'path';
-import { commands, workspace, window, StatusBarAlignment, MarkdownString } from 'vscode';
+import { commands, workspace, window, StatusBarAlignment } from 'vscode';
 import { COMMANDS, SETTINGS, STATUS_BAR_TEXTS, STORAGE_DIR_NAME } from './constants';
 import { getLoginCommand } from './commands/login';
 import { getValidateCommand } from './commands/validate';
@@ -7,7 +7,7 @@ import { getWatchCommand } from './commands/watch';
 import { getShowPanelCommand } from './commands/show-panel';
 import { getShowConfigurationCommand } from './commands/show-configuration';
 import { getBootstrapConfigurationCommand } from './commands/bootstrap-configuration';
-import { getDownloadPolicyCommand } from './commands/download-policy';
+import { getSynchronizeCommand } from './commands/synchronize';
 import { RuntimeContext } from './utils/runtime-context';
 import { SarifWatcher } from './utils/sarif-watcher';
 import { PolicyPuller } from './utils/policy-puller';
@@ -44,7 +44,7 @@ export function activate(context: ExtensionContext) {
   const commandShowPanel = commands.registerCommand(COMMANDS.SHOW_PANEL, getShowPanelCommand());
   const commandShowConfiguration = commands.registerCommand(COMMANDS.SHOW_CONFIGURATION, getShowConfigurationCommand());
   const commandBootstrapConfiguration = commands.registerCommand(COMMANDS.BOOTSTRAP_CONFIGURATION, getBootstrapConfigurationCommand());
-  const commandDownloadPolicy = commands.registerCommand(COMMANDS.DOWNLOAD_POLICY, getDownloadPolicyCommand(runtimeContext));
+  const commandDownloadPolicy = commands.registerCommand(COMMANDS.SYNCHRONIZE, getSynchronizeCommand(runtimeContext));
   const commandWatch = commands.registerCommand(COMMANDS.WATCH, getWatchCommand(runtimeContext));
 
   const configurationWatcher = workspace.onDidChangeConfiguration(async (event) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,11 +12,11 @@ import { RuntimeContext } from './utils/runtime-context';
 import { SarifWatcher } from './utils/sarif-watcher';
 import { PolicyPuller } from './utils/policy-puller';
 import { getTooltipContentDefault } from './utils/tooltip';
+import { getStoreAuthSync } from './utils/store';
+import { getLogoutCommand } from './commands/logout';
 import logger from './utils/logger';
 import globals from './utils/globals';
 import type { ExtensionContext } from 'vscode';
-import { getStoreAuthSync } from './utils/store';
-import { getLogoutCommand } from './commands/logout';
 
 let runtimeContext: RuntimeContext;
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -57,9 +57,7 @@ export function activate(context: ExtensionContext) {
     if (event.affectsConfiguration(SETTINGS.ENABLED_PATH)) {
       const enabled = globals.enabled;
       if (enabled) {
-        await runtimeContext.policyPuller.refresh();
-        await commands.executeCommand(COMMANDS.VALIDATE);
-        await commands.executeCommand(COMMANDS.WATCH);
+        await initialRun(runtimeContext);
       } else {
         await runtimeContext.dispose();
       }
@@ -86,12 +84,6 @@ export function activate(context: ExtensionContext) {
     await commands.executeCommand(COMMANDS.WATCH);
   });
 
-  runtimeContext.onSessionChanged(() => {
-    runtimeContext.policyPuller.refresh()
-      .then(() => commands.executeCommand(COMMANDS.VALIDATE))
-      .then(() => commands.executeCommand(COMMANDS.WATCH));
-  });
-
   context.subscriptions.push(
     commandLogin,
     commandLogout,
@@ -109,9 +101,7 @@ export function activate(context: ExtensionContext) {
     return;
   }
 
-  runtimeContext.policyPuller.refresh()
-    .then(() => commands.executeCommand(COMMANDS.VALIDATE))
-    .then(() => commands.executeCommand(COMMANDS.WATCH));
+  initialRun(runtimeContext);
 }
 
 export function deactivate() {
@@ -120,4 +110,16 @@ export function deactivate() {
   if (runtimeContext) {
     runtimeContext.dispose();
   }
+}
+
+function initialRun(runtimeContext: RuntimeContext) {
+  runtimeContext.onSessionChanged(() => {
+    runtimeContext.policyPuller.refresh()
+      .then(() => commands.executeCommand(COMMANDS.VALIDATE))
+      .then(() => commands.executeCommand(COMMANDS.WATCH));
+  });
+
+  runtimeContext.policyPuller.refresh()
+    .then(() => commands.executeCommand(COMMANDS.VALIDATE))
+    .then(() => commands.executeCommand(COMMANDS.WATCH));
 }

--- a/src/test/fixtures/auth.yaml
+++ b/src/test/fixtures/auth.yaml
@@ -1,0 +1,3 @@
+auth:
+  email: testuser@monokle.com
+  accessToken: testtoken

--- a/src/test/helpers/server.ts
+++ b/src/test/helpers/server.ts
@@ -10,6 +10,8 @@ const schema = `
   }
 
   type UserModel {
+    id: Int!
+    email: String!
     projects: [ProjectMemberModel!]!
   }
 

--- a/src/test/suite-basic/commands.test.ts
+++ b/src/test/suite-basic/commands.test.ts
@@ -16,6 +16,16 @@ suite(`Basic - Commands: ${process.env.ROOT_PATH}`, () => {
     await doSuiteTeardown();
   });
 
+  test('Exposes login command', async function() {
+    const commandList = await commands.getCommands(false);
+    ok(commandList.includes(COMMANDS.LOGIN));
+  });
+
+  test('Exposes logout command', async function() {
+    const commandList = await commands.getCommands(false);
+    ok(commandList.includes(COMMANDS.LOGOUT));
+  });
+
   test('Exposes validate command', async function() {
     const commandList = await commands.getCommands(false);
     ok(commandList.includes(COMMANDS.VALIDATE));

--- a/src/test/suite-basic/commands.test.ts
+++ b/src/test/suite-basic/commands.test.ts
@@ -48,6 +48,6 @@ suite(`Basic - Commands: ${process.env.ROOT_PATH}`, () => {
 
   test('Exposes download policy command', async () => {
     const commandList = await commands.getCommands(false);
-    ok(commandList.includes(COMMANDS.DOWNLOAD_POLICY));
+    ok(commandList.includes(COMMANDS.SYNCHRONIZE));
   });
 });

--- a/src/test/suite-policies/policies.test.ts
+++ b/src/test/suite-policies/policies.test.ts
@@ -1,6 +1,6 @@
 import { simpleGit } from 'simple-git';
 import { ok, deepEqual } from 'assert';
-import { workspace, window, ConfigurationTarget, Uri } from 'vscode';
+import { workspace, window, ConfigurationTarget } from 'vscode';
 import { spy } from 'sinon';
 import { join } from 'path';
 import { rm } from 'fs/promises';

--- a/src/test/suite-policies/policies.test.ts
+++ b/src/test/suite-policies/policies.test.ts
@@ -1,16 +1,21 @@
 import { simpleGit } from 'simple-git';
 import { ok, deepEqual } from 'assert';
-import { workspace, window, ConfigurationTarget } from 'vscode';
+import { workspace, window, commands, ConfigurationTarget } from 'vscode';
 import { spy } from 'sinon';
 import { join } from 'path';
+import { existsSync } from 'fs';
 import { rm } from 'fs/promises';
 import { getWorkspaceConfig, getWorkspaceFolders } from '../../utils/workspace';
 import { doSetup, doSuiteSetup, doSuiteTeardown } from '../helpers/suite';
 import { DEFAULT_POLICY } from '../helpers/server';
 import type { SinonSpy } from 'sinon';
 import type { Folder, WorkspaceFolderConfig } from '../../utils/workspace';
+import { COMMANDS } from '../../constants';
+import { getStoreAuth } from '../../utils/store';
 
 suite(`Policies - Remote: ${process.env.ROOT_PATH}`, () => {
+  let errorSpy: SinonSpy;
+
   suiteSetup(async () => {
     await doSuiteSetup();
   });
@@ -18,6 +23,12 @@ suite(`Policies - Remote: ${process.env.ROOT_PATH}`, () => {
   setup(async () => {
     await workspace.getConfiguration('monokle').update('enabled', false, ConfigurationTarget.Workspace);
     await doSetup();
+  });
+
+  teardown(async () => {
+    if (errorSpy) {
+      errorSpy.restore();
+    }
   });
 
   suiteTeardown(async () => {
@@ -41,7 +52,7 @@ suite(`Policies - Remote: ${process.env.ROOT_PATH}`, () => {
   // }).timeout(15000);
 
   test('Shows error notification when folder does not belong to a project', async () => {
-    const errorSpy = spy(window, 'showErrorMessage');
+    errorSpy = spy(window, 'showErrorMessage');
 
     const folders = getWorkspaceFolders();
     const folder = folders[0];
@@ -58,7 +69,7 @@ suite(`Policies - Remote: ${process.env.ROOT_PATH}`, () => {
     ok(`${errorSpy.args[0]}`.includes('repository does not belong to any project'));
   });
 
-  test('Fetches policy from remote API when URL set', async function () {
+  test('Fetches policy from remote API when authenticated', async function () {
     const folders = getWorkspaceFolders();
     const folder = folders[0];
 
@@ -80,6 +91,55 @@ suite(`Policies - Remote: ${process.env.ROOT_PATH}`, () => {
     ok(config);
     ok(config.isValid);
     deepEqual(config.config, DEFAULT_POLICY);
+  }).timeout(15000);
+
+  test('Refetches policy from remote API when authenticated and synchronize command run', async function () {
+    const folders = getWorkspaceFolders();
+    const folder = folders[0];
+
+    await removeGitDir(folder.uri.fsPath);
+
+    const git = simpleGit(folder.uri.fsPath);
+    await git.init().addRemote('origin', 'git@github.com:kubeshop/monokle-demo.git');
+
+    const remotes = await git.getRemotes(true);
+
+    ok(remotes.length > 0);
+    ok(remotes[0].name === 'origin');
+    ok(remotes[0].refs.fetch.includes('kubeshop/monokle-demo'));
+
+    await workspace.getConfiguration('monokle').update('enabled', true, ConfigurationTarget.Workspace);
+
+    const config = await waitForValidationConfig(folder, 10000);
+
+    ok(config);
+    ok(config.path);
+
+    await rm(config.path);
+
+    ok(existsSync(config.path) === false);
+
+    await commands.executeCommand(COMMANDS.SYNCHRONIZE);
+
+    const configNew = await waitForValidationConfig(folder, 10000);
+
+    deepEqual(configNew.config, DEFAULT_POLICY);
+  }).timeout(25000);
+
+  test('Logouts with logout command', async () => {
+    await workspace.getConfiguration('monokle').update('enabled', true, ConfigurationTarget.Workspace);
+
+    const userData = await getStoreAuth();
+
+    ok(userData.auth.email);
+    ok(userData.auth.accessToken);
+
+    await commands.executeCommand(COMMANDS.LOGOUT);
+
+    const userDataEmpty = await getStoreAuth();
+
+    ok(userDataEmpty?.auth?.email === undefined);
+    ok(userDataEmpty?.auth?.accessToken === undefined);
   }).timeout(15000);
 });
 

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -67,3 +67,18 @@ export async function raiseWarning(msg: string, actions?: ErrorAction[]) {
 
   return window.showWarningMessage(msg);
 }
+
+export async function raiseInfo(msg: string, actions?: ErrorAction[]) {
+  if (actions?.length) {
+    return window.showErrorMessage(msg, {}, ...actions)
+      .then(selectedAction => {
+        if (!selectedAction?.callback) {
+          return;
+        }
+
+        return selectedAction.callback();
+      });
+  }
+
+  return window.showInformationMessage(msg);
+}

--- a/src/utils/globals.ts
+++ b/src/utils/globals.ts
@@ -1,8 +1,9 @@
 import { workspace } from 'vscode';
-import { SETTINGS } from '../constants';
+import { DEFAULT_REMOTE_POLICY_URL, SETTINGS } from '../constants';
 
 class Globals {
   private _storagePath: string = '';
+  private _isAuthenticated: boolean = false;
 
   get storagePath() {
     return this._storagePath;
@@ -12,12 +13,24 @@ class Globals {
     this._storagePath = value;
   }
 
+  get isAuthenticated() {
+    return this._isAuthenticated;
+  }
+
+  set isAuthenticated(value) {
+    this._isAuthenticated = value;
+  }
+
   get configurationPath() {
     return workspace.getConfiguration(SETTINGS.NAMESPACE).get<string>(SETTINGS.CONFIGURATION_PATH);
   }
 
   get remotePolicyUrl() {
-    return workspace.getConfiguration(SETTINGS.NAMESPACE).get<string>(SETTINGS.REMOTE_POLICY_URL);
+    return process.env.MONOKLE_TEST_SERVER_URL ?? this.overwriteRemotePolicyUrl ?? DEFAULT_REMOTE_POLICY_URL;
+  }
+
+  get overwriteRemotePolicyUrl() {
+    return workspace.getConfiguration(SETTINGS.NAMESPACE).get<string>(SETTINGS.OVERWRITE_REMOTE_POLICY_URL);
   }
 
   get enabled() {
@@ -31,8 +44,10 @@ class Globals {
   asObject() {
     return {
       storagePath: this.storagePath,
+      isAuthenticated: this.isAuthenticated,
       configurationPath: this.configurationPath,
       remotePolicyUrl: this.remotePolicyUrl,
+      overwriteRemotePolicyUrl: this.overwriteRemotePolicyUrl,
       enabled: this.enabled,
       verbose: this.verbose,
     };

--- a/src/utils/globals.ts
+++ b/src/utils/globals.ts
@@ -1,9 +1,10 @@
 import { workspace } from 'vscode';
 import { DEFAULT_REMOTE_POLICY_URL, SETTINGS } from '../constants';
+import { getStoreAuthSync } from './store';
 
 class Globals {
   private _storagePath: string = '';
-  private _isAuthenticated: boolean = false;
+  private _activeUser: any = {};
 
   get storagePath() {
     return this._storagePath;
@@ -11,14 +12,6 @@ class Globals {
 
   set storagePath(value) {
     this._storagePath = value;
-  }
-
-  get isAuthenticated() {
-    return this._isAuthenticated;
-  }
-
-  set isAuthenticated(value) {
-    this._isAuthenticated = value;
   }
 
   get configurationPath() {
@@ -41,19 +34,33 @@ class Globals {
     return workspace.getConfiguration(SETTINGS.NAMESPACE).get<boolean>(SETTINGS.VERBOSE);
   }
 
+  get user() {
+    return {
+      isAuthenticated: Boolean(this._activeUser.auth?.accessToken),
+      email: this._activeUser.auth?.email,
+      accessToken: this._activeUser.auth?.accessToken,
+    };
+  }
+
+  refetchUser() {
+    this._activeUser = getStoreAuthSync() ?? {};
+  }
+
   asObject() {
     return {
       storagePath: this.storagePath,
-      isAuthenticated: this.isAuthenticated,
       configurationPath: this.configurationPath,
       remotePolicyUrl: this.remotePolicyUrl,
       overwriteRemotePolicyUrl: this.overwriteRemotePolicyUrl,
       enabled: this.enabled,
       verbose: this.verbose,
+      user: this.user,
     };
   }
 }
 
 const globalsInstance = new Globals();
+
+globalsInstance.refetchUser();
 
 export default globalsInstance;

--- a/src/utils/policy-puller.ts
+++ b/src/utils/policy-puller.ts
@@ -9,6 +9,7 @@ import { raiseCannotGetPolicyError, raiseError } from './errors';
 import logger from './logger';
 import globals from './globals';
 import type { Folder } from './workspace';
+import { getStoreAuth } from './store';
 
 const REFETCH_POLICY_INTERVAL_MS = 1000 * 30;
 
@@ -32,7 +33,7 @@ export class PolicyPuller {
   }
 
   async refresh() {
-    if (!this._url) {
+    if (!globals.isAuthenticated) {
       return this.dispose();
     }
 
@@ -71,7 +72,11 @@ export class PolicyPuller {
   }
 
   private async fetchPolicyFiles(roots: Folder[]) {
-    const userData = await getUser();
+    const storeAuth = await getStoreAuth();
+
+    logger.log('fetchPolicyFiles', storeAuth, roots);
+
+    const userData = await getUser(storeAuth.auth?.accessToken);
 
     logger.log('userData', userData);
 
@@ -121,7 +126,7 @@ export class PolicyPuller {
         continue;
       }
 
-      const repoPolicy = await getPolicy(repoProject.project.slug);
+      const repoPolicy = await getPolicy(repoProject.project.slug, storeAuth.auth?.accessToken);
 
       logger.log('repoPolicy', repoPolicy);
 

--- a/src/utils/policy-puller.ts
+++ b/src/utils/policy-puller.ts
@@ -97,7 +97,7 @@ export class PolicyPuller {
       if (!repoProject) {
         const projectUrl = getMonokleCloudUrl(globals.remotePolicyUrl, `/dashboard/projects`);
         raiseCannotGetPolicyError(
-          `The '${folder.name}' repository does not belong to any project in Monokle Cloud. Configure it and run ''Monokle: Validate' command.`,
+          `The '${folder.name}' repository does not belong to any project in Monokle Cloud. Configure it and run ''Monokle: Synchronize' command.`,
           [{
             title: 'Configure project',
             callback: () => {
@@ -115,7 +115,7 @@ export class PolicyPuller {
       const policyUrl = getMonokleCloudUrl(globals.remotePolicyUrl, `/dashboard/projects/${repoProject.project.slug}/policy`);
       if (!repoPolicy?.data?.getProject?.policy) {
         raiseCannotGetPolicyError(
-          `The '${folder.name}' repository project does not have policy defined. Configure it and run ''Monokle: Validate' command.`,
+          `The '${folder.name}' repository project does not have policy defined. Configure it and run ''Monokle: Synchronize' command.`,
           [{
             title: 'Configure policy',
             callback: () => {

--- a/src/utils/policy-puller.ts
+++ b/src/utils/policy-puller.ts
@@ -115,7 +115,7 @@ export class PolicyPuller {
       if (!repoProject) {
         const projectUrl = getMonokleCloudUrl(globals.remotePolicyUrl, `/dashboard/projects`);
         raiseCannotGetPolicyError(
-          `The '${folder.name}' repository does not belong to any project in Monokle Cloud.`,
+          `The '${folder.name}' repository does not belong to any project in Monokle Cloud. Configure it and run ''Monokle: Validate' command.`,
           [{
             title: 'Configure project',
             callback: () => {
@@ -133,7 +133,7 @@ export class PolicyPuller {
       const policyUrl = getMonokleCloudUrl(globals.remotePolicyUrl, `/dashboard/projects/${repoProject.project.slug}/policy`);
       if (!repoPolicy?.data?.getProject?.policy) {
         raiseCannotGetPolicyError(
-          `The '${folder.name}' repository project does not have policy defined.`,
+          `The '${folder.name}' repository project does not have policy defined. Configure it and run ''Monokle: Validate' command.`,
           [{
             title: 'Configure policy',
             callback: () => {

--- a/src/utils/policy-puller.ts
+++ b/src/utils/policy-puller.ts
@@ -9,31 +9,17 @@ import { raiseCannotGetPolicyError, raiseError } from './errors';
 import logger from './logger';
 import globals from './globals';
 import type { Folder } from './workspace';
-import { getStoreAuth } from './store';
 
 const REFETCH_POLICY_INTERVAL_MS = 1000 * 30;
 
 export class PolicyPuller {
 
-  private _url = '';
   private _isPulling = false;
   private _pullPromise: Promise<void> | undefined;
   private _policyFetcherId: NodeJS.Timer | undefined;
 
-  constructor(url: string) {
-    this.url = url;
-  }
-
-  get url() {
-    return this._url;
-  }
-
-  set url(value: string) {
-    this._url = value;
-  }
-
   async refresh() {
-    if (!globals.isAuthenticated) {
+    if (!globals.user.isAuthenticated) {
       return this.dispose();
     }
 
@@ -72,11 +58,7 @@ export class PolicyPuller {
   }
 
   private async fetchPolicyFiles(roots: Folder[]) {
-    const storeAuth = await getStoreAuth();
-
-    logger.log('fetchPolicyFiles', storeAuth, roots);
-
-    const userData = await getUser(storeAuth.auth?.accessToken);
+    const userData = await getUser(globals.user.accessToken);
 
     logger.log('userData', userData);
 
@@ -126,7 +108,7 @@ export class PolicyPuller {
         continue;
       }
 
-      const repoPolicy = await getPolicy(repoProject.project.slug, storeAuth.auth?.accessToken);
+      const repoPolicy = await getPolicy(repoProject.project.slug, globals.user.accessToken);
 
       logger.log('repoPolicy', repoPolicy);
 

--- a/src/utils/runtime-context.ts
+++ b/src/utils/runtime-context.ts
@@ -99,6 +99,6 @@ export class RuntimeContext {
   }
 
   private async updateTooltipContent() {
-    this._statusBarItem.tooltip = await getTooltipContent();
+    this._statusBarItem.tooltip = await getTooltipContent(this.user);
   }
 }

--- a/src/utils/store.ts
+++ b/src/utils/store.ts
@@ -1,0 +1,92 @@
+import envPaths from 'env-paths';
+import { Document, parse } from 'yaml';
+import { mkdirp } from 'mkdirp';
+import { existsSync, readFileSync } from 'fs';
+import { readFile, writeFile } from 'fs/promises';
+import { dirname, join, normalize } from 'path';
+
+type StoreAuth = {
+  auth?: {
+    email: string;
+    accessToken: string;
+  }
+};
+
+const CONFIG_FOLDER = 'monokle';
+const CONFIG_FILE_AUTH = 'auth.yaml';
+
+export async function getStoreAuth(): Promise<StoreAuth | undefined> {
+  const configPath = getStoreConfigPath(CONFIG_FILE_AUTH);
+  return getStoreData(configPath);
+}
+
+export function getStoreAuthSync(): StoreAuth | undefined {
+  const configPath = getStoreConfigPath(CONFIG_FILE_AUTH);
+  return getStoreDataSync(configPath);
+}
+
+export async function emptyStoreAuth(): Promise<boolean> {
+  const configPath = getStoreConfigPath(CONFIG_FILE_AUTH);
+  return writeStoreData(configPath, '');
+}
+
+export async function setStoreAuth(email: string, accessToken: string): Promise<boolean> {
+  const configPath = getStoreConfigPath(CONFIG_FILE_AUTH);
+  const configDoc = new Document();
+  configDoc.contents = ({
+    auth: {
+      email,
+      accessToken
+    }
+  } as any);
+
+  return writeStoreData(configPath, configDoc.toString());
+}
+
+function getStoreConfigPath(file: string): string {
+  const paths = envPaths(CONFIG_FOLDER, { suffix: '' });
+  const configPath = normalize(join(process.env.MONOKLE_TEST_CONFIG_PATH ?? paths.config, file));
+  return configPath;
+}
+
+async function getStoreData(file: string) {
+  if (!existsSync(file)) {
+    return undefined;
+  }
+
+  try {
+    const data = await readFile(file, 'utf8');
+    const config = parse(data);
+    return config;
+  } catch (err) {
+    console.error('Failed to read configuration from ' + file);
+    return undefined;
+  }
+}
+
+function getStoreDataSync(file: string) {
+  if (!existsSync(file)) {
+    return undefined;
+  }
+
+  try {
+    const data = readFileSync(file, 'utf8');
+    const config = parse(data);
+    return config;
+  } catch (err) {
+    console.error('Failed to read configuration from ' + file);
+    return undefined;
+  }
+}
+
+async function writeStoreData(file: string, data: string) {
+  const dir = dirname(file);
+
+  try {
+    await mkdirp(dir);
+    await writeFile(file, data);
+    return true;
+  } catch (err) {
+    return false;
+  }
+}

--- a/src/utils/tooltip.ts
+++ b/src/utils/tooltip.ts
@@ -11,7 +11,7 @@ export function getTooltipContentDefault() {
   return 'Monokle extension initializing...';
 }
 
-export async function getTooltipContent(activeUser?: string) {
+export async function getTooltipContent() {
   if (!globals.enabled) {
     return 'Monokle extension disabled';
   }
@@ -42,11 +42,11 @@ export async function getTooltipContent(activeUser?: string) {
   }));
 
   let activeUserText = '';
-  if (activeUser) {
-    activeUserText = `<br><br>Logged in as ${activeUser}`;
+  if (globals.user.isAuthenticated) {
+    activeUserText = `<hr><br>Logged in as **${globals.user.email}**`;
   }
 
-  const content = new MarkdownString(`${folderList.join('<br>')}${activeUserText}<br><br>Show validation panel`);
+  const content = new MarkdownString(`${folderList.join('<br>')}${activeUserText}<hr><br>Show validation panel`);
   content.supportHtml = true;
 
   return content;

--- a/src/utils/tooltip.ts
+++ b/src/utils/tooltip.ts
@@ -11,7 +11,7 @@ export function getTooltipContentDefault() {
   return 'Monokle extension initializing...';
 }
 
-export async function getTooltipContent() {
+export async function getTooltipContent(activeUser?: string) {
   if (!globals.enabled) {
     return 'Monokle extension disabled';
   }
@@ -41,7 +41,12 @@ export async function getTooltipContent() {
     return `**${folder.name}**: ❌ ${errors} ⚠️ ${warnings} (_config: ${configType}_)`;
   }));
 
-  const content = new MarkdownString(`${folderList.join('<br>')}<br><br>Show validation panel`);
+  let activeUserText = '';
+  if (activeUser) {
+    activeUserText = `<br><br>Logged in as ${activeUser}`;
+  }
+
+  const content = new MarkdownString(`${folderList.join('<br>')}${activeUserText}<br><br>Show validation panel`);
   content.supportHtml = true;
 
   return content;

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -71,6 +71,10 @@ export async function validateFolder(root: Folder): Promise<Uri | null> {
   const workspaceConfig = await getWorkspaceConfig(root);
 
   if (workspaceConfig.isValid === false) {
+    if (workspaceConfig.type === 'remote') {
+      return null; // Error will be already shown by policy puller.
+    }
+
     raiseInvalidConfigError(workspaceConfig, root);
     return null;
   }

--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -43,7 +43,7 @@ export async function getWorkspaceResources(workspaceFolder: Folder) {
 }
 
 export async function getWorkspaceConfig(workspaceFolder: Folder): Promise<WorkspaceFolderConfig> {
-  if (globals.isAuthenticated) {
+  if (globals.user.isAuthenticated) {
     // If given folder is not a git repo, we want to fallback to other options.
     const gitRepo = await isGitRepo(workspaceFolder.uri.fsPath);
     if (!gitRepo) {

--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -43,8 +43,7 @@ export async function getWorkspaceResources(workspaceFolder: Folder) {
 }
 
 export async function getWorkspaceConfig(workspaceFolder: Folder): Promise<WorkspaceFolderConfig> {
-  const remotePolicyUrl = workspace.getConfiguration(SETTINGS.NAMESPACE).get<string>(SETTINGS.REMOTE_POLICY_URL);
-  if (remotePolicyUrl) {
+  if (globals.isAuthenticated) {
     // If given folder is not a git repo, we want to fallback to other options.
     const gitRepo = await isGitRepo(workspaceFolder.uri.fsPath);
     if (!gitRepo) {


### PR DESCRIPTION
This PR adds token authentication flow to the extension.

## Changes

- Added `login` command.
    - Internally it grabs pasted token and saves it in local fs.
    - Having token means the user is authenticated which triggers policy puller which starts fetching policies (initially and periodically).
- Added `logout` command. 

## Fixes

- Mostly refactored some existing parts of the code.

## Future improvements

- I will work on README adjustments in separate PR (or add post-review) so we can review the code already.
- Keep in mind that logic related to auth (mostly `store.ts`), api communication (mostly `api.ts`) and probably git related should/will be extracted to separate core package/s.
- Maybe we can use build-in [authentication interface](https://code.visualstudio.com/api/references/vscode-api#authentication), looks a bit complex for token authentication only but maybe for later 🤔 (see examples [1](https://github.com/microsoft/vscode/blob/6d355a1ed5c168d1fc7a780bf455c79b4d586f8a/extensions/github-authentication/src/github.ts#L92), [2](https://www.eliostruyf.com/create-authentication-provider-visual-studio-code/)).
- I started to feel that code got a bit too closely tangled and some utils have too much knowledge/responsibility. It seems that we may need to go more into event-driven architecture or have something for better state management (or just clean it up, what I'm planning to do).

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [x] updated the docs
- [x] added a test
