### PR TITLE
fix: add a workaround for disabling initial SARIF aggresive UI

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,6 +28,10 @@ export async function activate(context: ExtensionContext): Promise<any> {
 
   logger.log('Activating extension...');
 
+  // Pre-configure SARIF extension (workaround for #16).
+  workspace.getConfiguration('sarif-viewer').update('connectToGithubCodeScanning', 'off');
+  workspace.getConfiguration('sarif-viewer.explorer').update('openWhenNoResults', false);
+
   let isActivated = false;
 
   const authenticator = await getAuthenticator();


### PR DESCRIPTION
This PR introduces a quick workaround for #16. It's not perfect as described in https://github.com/kubeshop/vscode-monokle/issues/16#issuecomment-1812286997:

> As a workaround, Monokle extension can override Sarif ext setting as mentioned in [#16 (comment)](https://github.com/kubeshop/vscode-monokle/issues/16#issuecomment-1635575035), but this has some caveats:
> 
> * It will result in changes in local `.vscode/settings.json` file which might be a bit confusing / not desired by users.
> * The `sarif-viewer.connectToGithubCodeScanning` takes effect only after VSC restart, so even when we disable it on the first run it still be visible on this first run (well, still better than for each run).

But maybe we can accept such behavior (and side-effects) at this stage?

@WitoDelnat WDYT?

## Changes

- As above.

## Fixes

- None.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
