### PR TITLE
Better support for setting origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,11 @@ With dedicated `Monokle: Bootstrap configuration` command, you can customize val
   <img src="assets/gifs/configuration.gif"/>
 </p>
 
-### Enforce policies with Monokle Cloud
+### Enforce policies with Monokle Cloud and Monokle Enterprise
 
-Quickly define and manage polices in Monokle Cloud which will be used for anyone working with the project in VSC.
+Quickly define and manage polices in Monokle Cloud or self-hosted Monokle Enterprise which will be used for anyone working with the project in VSC.
 
-#### Configure policies easily with Monokle Cloud
+#### Configure policies easily with Monokle
 
 <p align="center">
   <img src="assets/gifs/remote-policy-config.gif"/>
@@ -72,7 +72,7 @@ Quickly define and manage polices in Monokle Cloud which will be used for anyone
   <img src="assets/gifs/remote-policy-sync.gif"/>
 </p>
 
-See [**Monokle Cloud integration setup** section](#monokle-cloud-integration-setup) below on how to configure it.
+See [**Monokle Cloud/Enterprise integration setup** section](#monokle-cloudenterprise-integration-setup) below on how to configure it.
 
 
 ### Runs with commands
@@ -99,9 +99,11 @@ Read about these plugins and their individual validation rules in the [Core Plug
 
 To customize default configuration you can run `Monokle: Bootstrap validation` command to generate local `monokle.validation.yaml` configuration file in your project folder or connect with remote policy with Monokle Cloud.
 
-## Monokle Cloud integration setup
+## Monokle Cloud/Enterprise integration setup
 
 To use remote policy with Monokle extension you will need to create a project and configure policy for it in Monokle Cloud. Start by signing in to [Monokle Cloud](https://app.monokle.com).
+
+> **IMPORTANT**: The steps are the same for Monokle Enterprise. The main difference is that `monokle.origin` configuration needs to be changed to point to Enterprise instance (web app URL).
 
 > In case of doubts, refer to [Getting Started Guide](https://docs.monokle.com/tutorials/getting-started) or hit us directly on [Discord](https://discord.com/invite/6zupCZFQbe).
 
@@ -140,7 +142,7 @@ This extension contributes the following settings:
 * `monokle.enable` - Enable/disable this extension.
 * `monokle.configurationPath` - Set path to validation configuration file.
 * `monokle.verbose` - Log runtime info to VSC Developer Console.
-* `monokle.overwriteRemotePolicyUrl` - Overwrite default Monokle Cloud URL to fetch policies from.
+* `monokle.origin` - Overwrite default Monokle Cloud URL (e.g. when running own Monokle Enterprise instance).
 * `monokle.telemetryEnabled` - Enable/disable anonymous telemetry.
 
 ## Dependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@monokle/synchronizer": "^0.12.0",
         "@monokle/validation": "^0.31.6",
         "@segment/analytics-node": "^1.1.0",
+        "normalize-url": "^4.5.1",
         "p-retry": "^4.6.2",
         "uuid": "^9.0.0",
         "yaml": "^2.3.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.4.1",
       "dependencies": {
         "@monokle/parser": "^0.2.0",
-        "@monokle/synchronizer": "^0.8.0",
-        "@monokle/validation": "^0.29.1",
+        "@monokle/synchronizer": "^0.12.0",
+        "@monokle/validation": "^0.31.6",
         "@segment/analytics-node": "^1.1.0",
         "p-retry": "^4.6.2",
         "uuid": "^9.0.0",
@@ -836,9 +836,9 @@
       }
     },
     "node_modules/@monokle/synchronizer": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@monokle/synchronizer/-/synchronizer-0.8.0.tgz",
-      "integrity": "sha512-hO62PDnhrm0fWaNQSqT+uyB8x2kz+orh6deR0E/wJ1x+vE0ERNHuivaZkaGBBNyZbaBJWNjce3x86IaRJextHA==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@monokle/synchronizer/-/synchronizer-0.12.0.tgz",
+      "integrity": "sha512-5fPru1KlenSU4dY8cWZpNUoAaGtziFBAozbKGy9qVZsdD4GhEAZWAqQ+LE+UFvi7BBrYLDpWUITgrG+96ZMTxQ==",
       "dependencies": {
         "@monokle/types": "*",
         "env-paths": "^2.2.1",
@@ -877,18 +877,20 @@
       "integrity": "sha512-GGhl30a1WImxfxWg9Ys7MY1VQi2NU2iCH+gf4kKGZxS6nqAkgU4G1kTTYnxQzGNoM4Zbabh5aRxINsckIV5a+g=="
     },
     "node_modules/@monokle/validation": {
-      "version": "0.29.1",
-      "resolved": "https://registry.npmjs.org/@monokle/validation/-/validation-0.29.1.tgz",
-      "integrity": "sha512-wjv12Cox2zdOgUTJjRt0IUDsOD8HDtzt5SWb0xPLJ2UOQCfr3mLaM0rIJbT0cmUFgarFsvs8h5ZE/sQjRgeDBg==",
+      "version": "0.31.6",
+      "resolved": "https://registry.npmjs.org/@monokle/validation/-/validation-0.31.6.tgz",
+      "integrity": "sha512-u825P4scKWbmpPTYxIUhUnSKKps505poU0j1JZlRDJ5TCO4bOIDVMZD1YEqwEYb9KtaTvYm6sN+l+mJiDvhtjA==",
       "dependencies": {
         "@monokle/types": "*",
         "@open-policy-agent/opa-wasm": "1.8.0",
         "@rollup/plugin-virtual": "3.0.1",
         "ajv": "6.12.6",
         "change-case": "4.1.2",
+        "get-random-values": "^3.0.0",
         "isomorphic-fetch": "3.0.0",
         "lodash": "4.17.21",
         "node-fetch": "3.3.0",
+        "pako": "^2.1.0",
         "require-from-string": "2.0.2",
         "rollup": "3.18.0",
         "uuid": "9.0.0",
@@ -912,6 +914,11 @@
         "type": "opencollective",
         "url": "https://opencollective.com/node-fetch"
       }
+    },
+    "node_modules/@monokle/validation/node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
     },
     "node_modules/@monokle/validation/node_modules/yaml": {
       "version": "2.2.2",
@@ -2345,6 +2352,11 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dom-walk": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
+      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
+    },
     "node_modules/dot-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
@@ -3051,6 +3063,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-random-values": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/get-random-values/-/get-random-values-3.0.0.tgz",
+      "integrity": "sha512-mNznaBdYcpz7UAdnOtDGcLdNwAa79mXl5htEyyZ51YaeAWNf2g4x/2yCVBdNNTbi35wX0Stc2PJXM7G6rcONOA==",
+      "dependencies": {
+        "global": "^4.4.0"
+      },
+      "engines": {
+        "node": "18 || >=20"
+      }
+    },
     "node_modules/git-up": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/git-up/-/git-up-7.0.0.tgz",
@@ -3118,6 +3141,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/global": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
+      "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
+      "dependencies": {
+        "min-document": "^2.19.0",
+        "process": "^0.11.10"
       }
     },
     "node_modules/globals": {
@@ -3878,6 +3910,14 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/min-document": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+      "integrity": "sha512-9Wy1B3m3f66bPPmU5hdA4DR4PB2OfDU/+GS3yAB7IQozE3tqXaVv2zOjgla7MEGSRv95+ILmOuvhLkOK6wJtCQ==",
+      "dependencies": {
+        "dom-walk": "^0.1.0"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -4506,6 +4546,14 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/process-nextick-args": {

--- a/package.json
+++ b/package.json
@@ -89,13 +89,13 @@
           "default": null,
           "description": "Path to configuration file. If not set it will be searched in the workspace root."
         },
-        "monokle.overwriteRemotePolicyUrl": {
+        "monokle.origin": {
           "type": [
             "string",
             "null"
           ],
           "default": null,
-          "description": "Overwrite Monokle Cloud URL which is used to authenticate and fetch policies from. Useful when running on-premise Monokle Cloud."
+          "description": "Overwrite Monokle Cloud URL which is used to authenticate and fetch policies from. Useful when running Monokle Enterprise."
         },
         "monokle.telemetryEnabled": {
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -156,8 +156,8 @@
   },
   "dependencies": {
     "@monokle/parser": "^0.2.0",
-    "@monokle/synchronizer": "^0.8.0",
-    "@monokle/validation": "^0.29.1",
+    "@monokle/synchronizer": "^0.12.0",
+    "@monokle/validation": "^0.31.6",
     "@segment/analytics-node": "^1.1.0",
     "p-retry": "^4.6.2",
     "uuid": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -159,6 +159,7 @@
     "@monokle/synchronizer": "^0.12.0",
     "@monokle/validation": "^0.31.6",
     "@segment/analytics-node": "^1.1.0",
+    "normalize-url": "^4.5.1",
     "p-retry": "^4.6.2",
     "uuid": "^9.0.0",
     "yaml": "^2.3.1"

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -1,5 +1,5 @@
 import { env, Uri } from 'vscode';
-import { canRun } from '../utils/commands';
+import { canRun, disabledForLocal } from '../utils/commands';
 import { raiseError, raiseInfo } from '../utils/errors';
 import { COMMAND_NAMES } from '../constants';
 import { trackEvent } from '../utils/telemetry';
@@ -9,7 +9,7 @@ import type { RuntimeContext } from '../utils/runtime-context';
 
 export function getLoginCommand(context: RuntimeContext) {
   return async () => {
-    if (!canRun()) {
+    if (!canRun() || disabledForLocal(context, COMMAND_NAMES.LOGIN)) {
       return;
     }
 

--- a/src/commands/logout.ts
+++ b/src/commands/logout.ts
@@ -1,5 +1,5 @@
 import { commands } from 'vscode';
-import { canRun } from '../utils/commands';
+import { canRun, disabledForLocal } from '../utils/commands';
 import { raiseError, raiseInfo } from '../utils/errors';
 import { COMMAND_NAMES, COMMANDS } from '../constants';
 import { trackEvent } from '../utils/telemetry';
@@ -13,7 +13,7 @@ export type LogoutOptions = {
 
 export function getLogoutCommand(context: RuntimeContext) {
   return async (options: LogoutOptions) => {
-    if (!canRun()) {
+    if (!canRun() || disabledForLocal(context, COMMAND_NAMES.LOGOUT)) {
       return;
     }
 

--- a/src/commands/logout.ts
+++ b/src/commands/logout.ts
@@ -12,7 +12,7 @@ export type LogoutOptions = {
 };
 
 export function getLogoutCommand(context: RuntimeContext) {
-  return async (options: LogoutOptions) => {
+  return async (options?: LogoutOptions) => {
     if (!canRun() || disabledForLocal(context, COMMAND_NAMES.LOGOUT)) {
       return;
     }
@@ -38,7 +38,7 @@ export function getLogoutCommand(context: RuntimeContext) {
     try {
         await authenticator.logout();
 
-        if (options.originChanged) {
+        if (options?.originChanged) {
           raiseInfo('Logged out due to origin configuration change.', [{
             title: 'Login to new origin',
             callback: async () => commands.executeCommand(COMMANDS.LOGIN),

--- a/src/commands/synchronize.ts
+++ b/src/commands/synchronize.ts
@@ -1,5 +1,5 @@
 import { commands } from 'vscode';
-import { canRun } from '../utils/commands';
+import { canRun, disabledForLocal } from '../utils/commands';
 import { COMMANDS, COMMAND_NAMES } from '../constants';
 import { raiseWarning } from '../utils/errors';
 import { trackEvent } from '../utils/telemetry';
@@ -8,7 +8,7 @@ import type { RuntimeContext } from '../utils/runtime-context';
 
 export function getSynchronizeCommand(context: RuntimeContext) {
   return async () => {
-    if (!canRun()) {
+    if (!canRun() || disabledForLocal(context, COMMAND_NAMES.SYNCHRONIZE)) {
       return null;
     }
 
@@ -29,7 +29,7 @@ export function getSynchronizeCommand(context: RuntimeContext) {
       return null;
     }
 
-    await context.policyPuller.refresh();
+    await context.refreshPolicyPuller();
 
     trackEvent('command/synchronize', {
       status: 'success'

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -14,12 +14,12 @@ export const SETTINGS = {
   CONFIGURATION_PATH: 'configurationPath',
   VERBOSE: 'verbose',
   TELEMETRY_ENABLED: 'telemetryEnabled',
-  OVERWRITE_REMOTE_POLICY_URL: 'overwriteRemotePolicyUrl',
+  ORIGIN: 'origin',
   ENABLED_PATH: 'monokle.enabled',
   CONFIGURATION_PATH_PATH: 'monokle.configurationPath',
   VERBOSE_PATH: 'monokle.verbose',
   TELEMETRY_ENABLED_PATH: 'monokle.telemetryEnabled',
-  OVERWRITE_REMOTE_POLICY_URL_PATH: 'monokle.overwriteRemotePolicyUrl',
+  ORIGIN_PATH: 'monokle.origin',
 };
 
 export const COMMANDS = {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -43,7 +43,7 @@ export async function activate(context: ExtensionContext): Promise<any> {
   statusBarItem.command = COMMANDS.SHOW_PANEL;
   statusBarItem.show();
 
-  // TODO this may fail due to invalid or unrechable origin.
+  // @TODO this may fail due to invalid or unreachable origin, what then?
   const authenticator = await getAuthenticator(globals.origin);
   const synchronizer = await getSynchronizer(globals.origin);
 
@@ -121,7 +121,9 @@ export async function activate(context: ExtensionContext): Promise<any> {
       // 3. Propagate them to global context via runtimeContext.
       // 4. Run validation.
       if ((await globals.getUser()).isAuthenticated) {
-        await commands.executeCommand(COMMANDS.LOGOUT);
+        await commands.executeCommand(COMMANDS.LOGOUT, {
+          originChanged: true,
+        });
       }
 
       try {

--- a/src/test/fixtures/folder-with-config/.vscode/settings.json
+++ b/src/test/fixtures/folder-with-config/.vscode/settings.json
@@ -1,4 +1,3 @@
 {
-    "monokle.enabled": false,
-    "monokle.remotePolicyUrl": "http://localhost:5000"
+    "monokle.enabled": false
 }

--- a/src/test/helpers/run.ts
+++ b/src/test/helpers/run.ts
@@ -6,7 +6,8 @@ export function runTestsFromDir(dir: string): Promise<void> {
   // Create the mocha test
   const mocha = new Mocha({
     ui: 'tdd',
-    color: true
+    color: true,
+    timeout: 10000,
   });
 
   const testsRoot = resolve(dir);

--- a/src/utils/authentication.ts
+++ b/src/utils/authentication.ts
@@ -1,5 +1,7 @@
 import globals from './globals';
 
+export type Authenticator = Awaited<ReturnType<typeof getAuthenticator>>;
+
 export const AUTH_CLIENT_ID = 'mc-cli';
 
 export async function getAuthenticator(origin?: string) {
@@ -14,9 +16,7 @@ export async function getAuthenticator(origin?: string) {
   }
   /* DEV_ONLY_END */
 
-  const {createMonokleAuthenticatorFromOrigin, DEFAULT_ORIGIN} = await import('@monokle/synchronizer');
-
-  globals.defaultOrigin = DEFAULT_ORIGIN;
+  const {createMonokleAuthenticatorFromOrigin} = await import('@monokle/synchronizer');
 
   try {
     const authenticator = await createMonokleAuthenticatorFromOrigin(AUTH_CLIENT_ID, origin);

--- a/src/utils/authentication.ts
+++ b/src/utils/authentication.ts
@@ -1,3 +1,5 @@
+import globals from './globals';
+
 export const AUTH_CLIENT_ID = 'mc-cli';
 
 export async function getAuthenticator(origin?: string) {
@@ -12,13 +14,15 @@ export async function getAuthenticator(origin?: string) {
   }
   /* DEV_ONLY_END */
 
-  const {createMonokleAuthenticatorFromOrigin} = await import('@monokle/synchronizer');
+  const {createMonokleAuthenticatorFromOrigin, DEFAULT_ORIGIN} = await import('@monokle/synchronizer');
+
+  globals.defaultOrigin = DEFAULT_ORIGIN;
 
   try {
     const authenticator = await createMonokleAuthenticatorFromOrigin(AUTH_CLIENT_ID, origin);
     return authenticator;
   } catch (err: any) {
-    // Without this entire extension can't run. Needs to be obvious to users what went wrong and how to fix.
+    // Without this entire extension can run only in local mode. Needs to be obvious to users what went wrong and how to fix.
     throw err;
   }
 }

--- a/src/utils/authentication.ts
+++ b/src/utils/authentication.ts
@@ -1,4 +1,6 @@
-export async function getAuthenticator() {
+export const AUTH_CLIENT_ID = 'mc-cli';
+
+export async function getAuthenticator(origin?: string) {
   /* DEV_ONLY_START */
   if (process.env.MONOKLE_VSC_ENV === 'TEST') {
     const {Authenticator, StorageHandlerAuth, ApiHandler, DeviceFlowHandler} = await import('@monokle/synchronizer');
@@ -10,6 +12,13 @@ export async function getAuthenticator() {
   }
   /* DEV_ONLY_END */
 
-  const {createDefaultMonokleAuthenticator} = await import('@monokle/synchronizer');
-  return createDefaultMonokleAuthenticator();
+  const {createMonokleAuthenticatorFromOrigin} = await import('@monokle/synchronizer');
+
+  try {
+    const authenticator = await createMonokleAuthenticatorFromOrigin(AUTH_CLIENT_ID, origin);
+    return authenticator;
+  } catch (err: any) {
+    // Without this entire extension can't run. Needs to be obvious to users what went wrong and how to fix.
+    throw err;
+  }
 }

--- a/src/utils/authentication.ts
+++ b/src/utils/authentication.ts
@@ -1,5 +1,3 @@
-import globals from './globals';
-
 export type Authenticator = Awaited<ReturnType<typeof getAuthenticator>>;
 
 export const AUTH_CLIENT_ID = 'mc-cli';

--- a/src/utils/commands.ts
+++ b/src/utils/commands.ts
@@ -1,6 +1,7 @@
 import { workspace, window } from 'vscode';
 import { SETTINGS } from '../constants';
-import { raiseInfo } from './errors';
+import { raiseInfo, raiseWarning } from './errors';
+import { RuntimeContext } from './runtime-context';
 
 export function canRun() {
   const isEnabled = workspace.getConfiguration(SETTINGS.NAMESPACE).get(SETTINGS.ENABLED);
@@ -9,4 +10,19 @@ export function canRun() {
   }
 
   return isEnabled;
+}
+
+export function disabledForLocal(context: RuntimeContext, command: string) {
+  if (context.isLocal) {
+    raiseWarning(
+      `Command ${command} is not available in local mode. Make sure you are connected to the internet and have correct 'monokle.origin' configured.`,
+      [],
+      {
+        modal: true,
+      },
+    );
+    return true;
+  }
+
+  return false;
 }

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -24,7 +24,7 @@ export function getInvalidConfigError(config: WorkspaceFolderConfig) {
   }
 
   if (config.type === 'remote') {
-    errorMsg = `Your remote configuration file from '${globals.remotePolicyUrl}' is invalid.`;
+    errorMsg = `Your remote configuration file from '${globals.origin}' is invalid.`;
   }
 
   return errorMsg;

--- a/src/utils/globals.ts
+++ b/src/utils/globals.ts
@@ -27,12 +27,12 @@ class Globals {
     return workspace.getConfiguration(SETTINGS.NAMESPACE).get<string>(SETTINGS.CONFIGURATION_PATH);
   }
 
-  get remotePolicyUrl() {
-    return process.env.MONOKLE_TEST_SERVER_URL ?? this.overwriteRemotePolicyUrl ?? DEFAULT_REMOTE_POLICY_URL;
+  get remotePolicyUrl() { // @TODO this should be dropped
+    return process.env.MONOKLE_TEST_SERVER_URL ?? this.origin ?? '';
   }
 
-  get overwriteRemotePolicyUrl() {
-    return workspace.getConfiguration(SETTINGS.NAMESPACE).get<string>(SETTINGS.OVERWRITE_REMOTE_POLICY_URL);
+  get origin() {
+    return workspace.getConfiguration(SETTINGS.NAMESPACE).get<string>(SETTINGS.ORIGIN);
   }
 
   get enabled() {
@@ -66,7 +66,7 @@ class Globals {
 
     try {
       const user = await this._authenticator.getUser();
-      const projectInfo = await this._synchronizer.getProjectInfo(path, user.token);
+      const projectInfo = await this._synchronizer.getProjectInfo(path, user.tokenInfo);
       return projectInfo?.name ?? '';
     } catch (err) {
       return '';
@@ -122,7 +122,7 @@ class Globals {
       storagePath: this.storagePath,
       configurationPath: this.configurationPath,
       remotePolicyUrl: this.remotePolicyUrl,
-      overwriteRemotePolicyUrl: this.overwriteRemotePolicyUrl,
+      origin: this.origin,
       enabled: this.enabled,
       verbose: this.verbose,
     };

--- a/src/utils/globals.ts
+++ b/src/utils/globals.ts
@@ -1,3 +1,4 @@
+import normalizeUrl from 'normalize-url';
 import { workspace } from 'vscode';
 import { SETTINGS } from '../constants';
 import { Folder } from './workspace';
@@ -38,6 +39,15 @@ class Globals {
 
   get origin() {
     return workspace.getConfiguration(SETTINGS.NAMESPACE).get<string>(SETTINGS.ORIGIN) || this._defaultOrigin;
+  }
+
+  get originFormatted() {
+    return normalizeUrl(this.origin, {
+      stripHash: true,
+      stripProtocol: true,
+      stripWWW: true,
+      removeTrailingSlash: true,
+    });
   }
 
   get enabled() {

--- a/src/utils/globals.ts
+++ b/src/utils/globals.ts
@@ -68,6 +68,12 @@ class Globals {
   }
 
   async getUser(): Promise<Authenticator['user']> {
+    if (this._runtimeContext.isLocal) {
+      return {
+        isAuthenticated: false,
+      } as Authenticator['user'];
+    }
+
     if (!this._runtimeContext?.authenticator) {
       throw new Error('Authenticator not initialized for globals.');
     }
@@ -76,6 +82,10 @@ class Globals {
   }
 
   async getRemoteProjectName(path: string) {
+    if (this._runtimeContext.isLocal) {
+      return '';
+    }
+
     if (!this._runtimeContext?.authenticator) {
       throw new Error('Authenticator not initialized for globals.');
     }
@@ -94,6 +104,14 @@ class Globals {
   }
 
   async getRemotePolicy(path: string) {
+    if (this._runtimeContext.isLocal) {
+      return {
+        valid: false,
+        path: '',
+        policy: {},
+      };
+    }
+
     if (!this._runtimeContext?.synchronizer) {
       throw new Error('Synchronizer not initialized for globals.');
     }
@@ -122,6 +140,10 @@ class Globals {
   }
 
   async forceRefreshToken() {
+    if (this._runtimeContext.isLocal) {
+      return;
+    }
+
     if (!this._runtimeContext?.authenticator) {
       throw new Error('Authenticator not initialized for globals.');
     }

--- a/src/utils/globals.ts
+++ b/src/utils/globals.ts
@@ -1,8 +1,9 @@
 import { workspace } from 'vscode';
-import { DEFAULT_REMOTE_POLICY_URL, SETTINGS } from '../constants';
+import { SETTINGS } from '../constants';
 import { getAuthenticator } from './authentication';
 import { getSynchronizer } from './synchronization';
 import { Folder } from './workspace';
+import { RuntimeContext } from './runtime-context';
 
 export type FolderStatus = {
   valid: boolean;
@@ -14,6 +15,7 @@ class Globals {
   private statuses: Record<string, FolderStatus> = {};
   private _authenticator: Awaited<ReturnType<typeof getAuthenticator>> = null;
   private _synchronizer: Awaited<ReturnType<typeof getSynchronizer>> = null;
+  private _defaultOrigin: string = '';
 
   get storagePath() {
     return this._storagePath;
@@ -32,7 +34,7 @@ class Globals {
   }
 
   get origin() {
-    return workspace.getConfiguration(SETTINGS.NAMESPACE).get<string>(SETTINGS.ORIGIN);
+    return workspace.getConfiguration(SETTINGS.NAMESPACE).get<string>(SETTINGS.ORIGIN) || this._defaultOrigin;
   }
 
   get enabled() {
@@ -45,6 +47,10 @@ class Globals {
 
   get telemetryEnabled() {
     return workspace.getConfiguration(SETTINGS.NAMESPACE).get<boolean>(SETTINGS.TELEMETRY_ENABLED);
+  }
+
+  set defaultOrigin(value: string) {
+    this._defaultOrigin = value;
   }
 
   async getUser(): Promise<Awaited<ReturnType<typeof getAuthenticator>>['user']> {

--- a/src/utils/policy-puller.ts
+++ b/src/utils/policy-puller.ts
@@ -112,7 +112,7 @@ export class PolicyPuller {
       }
 
       const user = await globals.getUser();
-      const policy = await this._synchronizer.synchronize(root.uri.fsPath, user.token);
+      const policy = await this._synchronizer.synchronize(root.uri.fsPath, user.tokenInfo);
 
       return policy;
     }, {

--- a/src/utils/policy-puller.ts
+++ b/src/utils/policy-puller.ts
@@ -1,10 +1,10 @@
 import { rm } from 'fs/promises';
-import pRetry, {AbortError} from 'p-retry';
+import pRetry from 'p-retry';
 import { getWorkspaceFolders } from './workspace';
-import { getSynchronizer } from './synchronization';
 import { trackEvent } from './telemetry';
 import logger from './logger';
 import globals from './globals';
+import type { Synchronizer } from './synchronization';
 import type { Folder } from './workspace';
 
 const REFETCH_POLICY_INTERVAL_MS = 1000 * 30;
@@ -16,7 +16,7 @@ export class PolicyPuller {
   private _policyFetcherId: NodeJS.Timer | undefined;
 
   constructor(
-    private _synchronizer: Awaited<ReturnType<typeof getSynchronizer>>
+    private _synchronizer: Synchronizer
   ) {}
 
   async refresh() {

--- a/src/utils/runtime-context.ts
+++ b/src/utils/runtime-context.ts
@@ -15,10 +15,14 @@ export class RuntimeContext {
     private _extensionContext: ExtensionContext,
     private _sarifWatcher: SarifWatcher,
     private _policyPuller: PolicyPuller,
-    private _authenticator: Authenticator,
-    private _synchronizer: Synchronizer,
+    private _authenticator: Authenticator | undefined,
+    private _synchronizer: Synchronizer | undefined,
     private _statusBarItem: StatusBarItem
   ) {}
+
+  get isLocal() {
+    return !this._authenticator || !this._synchronizer;
+  }
 
   get extensionContext() {
     return this._extensionContext;
@@ -56,6 +60,14 @@ export class RuntimeContext {
     }
   }
 
+  async refreshPolicyPuller() {
+    if (!this.policyPuller) {
+      return;
+    }
+
+    await this.policyPuller.refresh();
+  }
+
   async reconfigure(
     policyPuller: PolicyPuller,
     authenticator: Authenticator,
@@ -76,6 +88,12 @@ export class RuntimeContext {
     this._policyPuller = policyPuller;
     this._authenticator = authenticator;
     this._synchronizer = synchronizer;
+  }
+
+  localOnly() {
+    this._policyPuller = undefined;
+    this._authenticator = undefined;
+    this._synchronizer = undefined;
   }
 
   async updateTooltip() {
@@ -101,6 +119,14 @@ export class RuntimeContext {
 
     if (this.sarifWatcher) {
       await this.sarifWatcher.dispose();
+    }
+
+    if (this.authenticator) {
+      this.authenticator.removeAllListeners();
+    }
+
+    if (this.synchronizer) {
+      this.synchronizer.removeAllListeners();
     }
   }
 }

--- a/src/utils/runtime-context.ts
+++ b/src/utils/runtime-context.ts
@@ -56,6 +56,20 @@ export class RuntimeContext {
     }
   }
 
+  async reconfigure(
+    policyPuller: PolicyPuller,
+    authenticator: Awaited<ReturnType<typeof getAuthenticator>>,
+    synchronizer: Awaited<ReturnType<typeof getSynchronizer>>,
+  ) {
+    if (this.policyPuller) {
+      await this.policyPuller.dispose();
+    }
+
+    this._policyPuller = policyPuller;
+    this._authenticator = authenticator;
+    this._synchronizer = synchronizer;
+  }
+
   async updateTooltip() {
     const tooltipData = await getTooltipData();
     this._statusBarItem.text = tooltipData.status === 'ok' ? STATUS_BAR_TEXTS.DEFAULT : STATUS_BAR_TEXTS.ERROR;

--- a/src/utils/runtime-context.ts
+++ b/src/utils/runtime-context.ts
@@ -1,8 +1,8 @@
 
 import { STATUS_BAR_TEXTS } from '../constants';
 import { getTooltipData } from './tooltip';
-import { getAuthenticator } from './authentication';
-import { getSynchronizer } from './synchronization';
+import type { Authenticator } from './authentication';
+import type { Synchronizer } from './synchronization';
 import type { Disposable, ExtensionContext, StatusBarItem } from 'vscode';
 import type { SarifWatcher } from './sarif-watcher';
 import type { PolicyPuller } from './policy-puller';
@@ -15,8 +15,8 @@ export class RuntimeContext {
     private _extensionContext: ExtensionContext,
     private _sarifWatcher: SarifWatcher,
     private _policyPuller: PolicyPuller,
-    private _authenticator: Awaited<ReturnType<typeof getAuthenticator>>,
-    private _synchronizer: Awaited<ReturnType<typeof getSynchronizer>>,
+    private _authenticator: Authenticator,
+    private _synchronizer: Synchronizer,
     private _statusBarItem: StatusBarItem
   ) {}
 
@@ -58,11 +58,19 @@ export class RuntimeContext {
 
   async reconfigure(
     policyPuller: PolicyPuller,
-    authenticator: Awaited<ReturnType<typeof getAuthenticator>>,
-    synchronizer: Awaited<ReturnType<typeof getSynchronizer>>,
+    authenticator: Authenticator,
+    synchronizer: Synchronizer,
   ) {
     if (this.policyPuller) {
       await this.policyPuller.dispose();
+    }
+
+    if (this.authenticator) {
+      this.authenticator.removeAllListeners();
+    }
+
+    if (this.synchronizer) {
+      this.synchronizer.removeAllListeners();
     }
 
     this._policyPuller = policyPuller;

--- a/src/utils/synchronization.ts
+++ b/src/utils/synchronization.ts
@@ -1,5 +1,3 @@
-import globals from './globals';
-
 export type Synchronizer = Awaited<ReturnType<typeof getSynchronizer>>;
 
 export async function getSynchronizer(origin?: string) {

--- a/src/utils/synchronization.ts
+++ b/src/utils/synchronization.ts
@@ -1,5 +1,7 @@
 import globals from './globals';
 
+export type Synchronizer = Awaited<ReturnType<typeof getSynchronizer>>;
+
 export async function getSynchronizer(origin?: string) {
   /* DEV_ONLY_START */
   if (process.env.MONOKLE_VSC_ENV === 'TEST') {
@@ -23,9 +25,7 @@ export async function getSynchronizer(origin?: string) {
   }
   /* DEV_ONLY_END */
 
-  const {createMonokleSynchronizerFromOrigin, DEFAULT_ORIGIN} = await import('@monokle/synchronizer');
-
-  globals.defaultOrigin = DEFAULT_ORIGIN;
+  const {createMonokleSynchronizerFromOrigin} = await import('@monokle/synchronizer');
 
   try {
     const synchronizer = await createMonokleSynchronizerFromOrigin(origin);

--- a/src/utils/synchronization.ts
+++ b/src/utils/synchronization.ts
@@ -1,4 +1,4 @@
-export async function getSynchronizer() {
+export async function getSynchronizer(origin?: string) {
   /* DEV_ONLY_START */
   if (process.env.MONOKLE_VSC_ENV === 'TEST') {
     const {Synchronizer, StorageHandlerPolicy, ApiHandler, GitHandler} = await import('@monokle/synchronizer');
@@ -21,6 +21,13 @@ export async function getSynchronizer() {
   }
   /* DEV_ONLY_END */
 
-  const {createDefaultMonokleSynchronizer} = await import('@monokle/synchronizer');
-  return createDefaultMonokleSynchronizer();
+  const {createMonokleSynchronizerFromOrigin} = await import('@monokle/synchronizer');
+
+  try {
+    const synchronizer = await createMonokleSynchronizerFromOrigin(origin);
+    return synchronizer;
+  } catch (err: any) {
+    // Without this entire extension can't run. Needs to be obvious to users what went wrong and how to fix.
+    throw err;
+  }
 }

--- a/src/utils/synchronization.ts
+++ b/src/utils/synchronization.ts
@@ -1,3 +1,5 @@
+import globals from './globals';
+
 export async function getSynchronizer(origin?: string) {
   /* DEV_ONLY_START */
   if (process.env.MONOKLE_VSC_ENV === 'TEST') {
@@ -21,13 +23,15 @@ export async function getSynchronizer(origin?: string) {
   }
   /* DEV_ONLY_END */
 
-  const {createMonokleSynchronizerFromOrigin} = await import('@monokle/synchronizer');
+  const {createMonokleSynchronizerFromOrigin, DEFAULT_ORIGIN} = await import('@monokle/synchronizer');
+
+  globals.defaultOrigin = DEFAULT_ORIGIN;
 
   try {
     const synchronizer = await createMonokleSynchronizerFromOrigin(origin);
     return synchronizer;
   } catch (err: any) {
-    // Without this entire extension can't run. Needs to be obvious to users what went wrong and how to fix.
+    // Without this entire extension can run only in local mode. Needs to be obvious to users what went wrong and how to fix.
     throw err;
   }
 }

--- a/src/utils/tooltip.ts
+++ b/src/utils/tooltip.ts
@@ -70,7 +70,7 @@ export async function getTooltipData(): Promise<TooltipData> {
 
   const user = await globals.getUser();
   if (user.isAuthenticated) {
-    activeUserText = `<hr><br>Logged in as **${user.email}**`;
+    activeUserText = `<hr><br>Logged in as **${user.email}** with **${globals.origin}**`;
   }
 
   const content = new MarkdownString(`${folderList.join('<br>')}${activeUserText}<hr><br>Click to show validation panel`);

--- a/src/utils/tooltip.ts
+++ b/src/utils/tooltip.ts
@@ -70,7 +70,7 @@ export async function getTooltipData(): Promise<TooltipData> {
 
   const user = await globals.getUser();
   if (user.isAuthenticated) {
-    activeUserText = `<hr><br>Logged in as **${user.email}** with **${globals.origin}**`;
+    activeUserText = `<hr><br>Logged in as **${user.email}** with **${globals.originFormatted}**`;
   }
 
   const content = new MarkdownString(`${folderList.join('<br>')}${activeUserText}<hr><br>Click to show validation panel`);


### PR DESCRIPTION
This PR fixes #47.

![monokle 20231121-1](https://github.com/kubeshop/vscode-monokle/assets/1061942/2817adb6-1b2f-46a3-8985-5583ff7ffffe)

## Changes

- Reworked `overwriteRemotePolicyUrl` as `origin` setting. It can be now set anytime and extension will react accordingly.
- Reworked a bit how extension is initialized and global/runtime context handled to simplify code.
- Added better handling of "local mode" - meaning when user is offline or origin value invalid, extension still will function correctly (without login/sync abilities).

## Fixes

- None.

## Checklist

- [x] tested locally
- [x] added new dependencies
- [ ] updated the docs
- [ ] added a test
