### PR TITLE
Introduce 'project' setting

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,8 +5,6 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - main
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 

--- a/README.md
+++ b/README.md
@@ -144,9 +144,9 @@ This extension contributes the following settings:
 * `monokle.verbose` - Log runtime info to VSC Developer Console.
 * `monokle.origin` - Overwrite default Monokle Cloud URL (e.g. when running own Monokle Enterprise instance).
 * `monokle.telemetryEnabled` - Enable/disable anonymous telemetry.
-* `monokle.projectId` - Define remote project from which policy should be used for validation.
+* `monokle.project` - Define remote project from which policy should be used for validation.
 
-> **IMPORTANT**: Project id can be obtain on Project details page from URL https://app.monokle.com/dashboard/projects/<projectId>.
+> **IMPORTANT**: Project id used for `monokle.project` can be obtain on Project details page from current URL `https://app.monokle.com/dashboard/projects/<projectId>`.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -144,6 +144,9 @@ This extension contributes the following settings:
 * `monokle.verbose` - Log runtime info to VSC Developer Console.
 * `monokle.origin` - Overwrite default Monokle Cloud URL (e.g. when running own Monokle Enterprise instance).
 * `monokle.telemetryEnabled` - Enable/disable anonymous telemetry.
+* `monokle.projectId` - Define remote project from which policy should be used for validation.
+
+> **IMPORTANT**: Project id can be obtain on Project details page from URL https://app.monokle.com/dashboard/projects/<projectId>.
 
 ## Dependencies
 

--- a/package.json
+++ b/package.json
@@ -112,13 +112,13 @@
           "default": false,
           "description": "Log runtime info to Developer Console."
         },
-        "monokle.projectId": {
+        "monokle.project": {
           "type": [
             "string",
             "null"
           ],
           "default": null,
-          "description": "Project ID which policy will be used for validation. If not set it will deducted based on git repository URL."
+          "description": "Project which policy will be used for validation. If not set it will deducted based on git repository URL."
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -111,6 +111,14 @@
           "type": "boolean",
           "default": false,
           "description": "Log runtime info to Developer Console."
+        },
+        "monokle.projectId": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null,
+          "description": "Project ID which policy will be used for validation. If not set it will deducted based on git repository URL."
         }
       }
     }

--- a/src/commands/show-configuration.ts
+++ b/src/commands/show-configuration.ts
@@ -5,6 +5,7 @@ import { createTemporaryConfigFile } from '../utils/validation';
 import { trackEvent } from '../utils/telemetry';
 import globals from '../utils/globals';
 import { getFixTip } from '../utils/get-fix-tip';
+import { COMMANDS } from '../constants';
 import type { Folder } from '../utils/workspace';
 
 type FolderItem = {
@@ -27,6 +28,8 @@ export function getShowConfigurationCommand() {
     if (!folders.length) {
       return null;
     }
+
+    await commands.executeCommand(COMMANDS.SYNCHRONIZE);
 
     const showConfig = async (folder: Folder) => {
       const config = await getWorkspaceConfig(folder);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -15,11 +15,13 @@ export const SETTINGS = {
   VERBOSE: 'verbose',
   TELEMETRY_ENABLED: 'telemetryEnabled',
   ORIGIN: 'origin',
+  PROJECT_ID: 'projectId',
   ENABLED_PATH: 'monokle.enabled',
   CONFIGURATION_PATH_PATH: 'monokle.configurationPath',
   VERBOSE_PATH: 'monokle.verbose',
   TELEMETRY_ENABLED_PATH: 'monokle.telemetryEnabled',
   ORIGIN_PATH: 'monokle.origin',
+  PROJECT_ID_PATH: 'monokle.projectId',
 };
 
 export const COMMANDS = {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -15,13 +15,13 @@ export const SETTINGS = {
   VERBOSE: 'verbose',
   TELEMETRY_ENABLED: 'telemetryEnabled',
   ORIGIN: 'origin',
-  PROJECT_ID: 'projectId',
+  PROJECT: 'project',
   ENABLED_PATH: 'monokle.enabled',
   CONFIGURATION_PATH_PATH: 'monokle.configurationPath',
   VERBOSE_PATH: 'monokle.verbose',
   TELEMETRY_ENABLED_PATH: 'monokle.telemetryEnabled',
   ORIGIN_PATH: 'monokle.origin',
-  PROJECT_ID_PATH: 'monokle.projectId',
+  PROJECT_PATH: 'monokle.project',
 };
 
 export const COMMANDS = {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -146,11 +146,11 @@ export async function activate(context: ExtensionContext): Promise<any> {
       }
     }
 
-    if (event.affectsConfiguration(SETTINGS.PROJECT_ID_PATH)) {
+    if (event.affectsConfiguration(SETTINGS.PROJECT_PATH)) {
       trackEvent('config/change', {
         status: 'success',
-        name: SETTINGS.PROJECT_ID,
-        value: String(globals.projectId),
+        name: SETTINGS.PROJECT,
+        value: String(globals.project),
       });
 
       await commands.executeCommand(COMMANDS.VALIDATE);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -145,6 +145,16 @@ export async function activate(context: ExtensionContext): Promise<any> {
         await closeTelemetry();
       }
     }
+
+    if (event.affectsConfiguration(SETTINGS.PROJECT_ID_PATH)) {
+      trackEvent('config/change', {
+        status: 'success',
+        name: SETTINGS.PROJECT_ID,
+        value: String(globals.projectId),
+      });
+
+      await commands.executeCommand(COMMANDS.VALIDATE);
+    }
   });
 
   const workspaceWatcher = workspace.onDidChangeWorkspaceFolders(async () => {

--- a/src/utils/globals.ts
+++ b/src/utils/globals.ts
@@ -62,6 +62,10 @@ class Globals {
     return workspace.getConfiguration(SETTINGS.NAMESPACE).get<boolean>(SETTINGS.TELEMETRY_ENABLED);
   }
 
+  get projectId() {
+    return workspace.getConfiguration(SETTINGS.NAMESPACE).get<string>(SETTINGS.PROJECT_ID);
+  }
+
   async setDefaultOrigin() {
     const {DEFAULT_ORIGIN} = await import('@monokle/synchronizer');
     this._defaultOrigin = DEFAULT_ORIGIN;
@@ -96,7 +100,10 @@ class Globals {
 
     try {
       const user = await this._runtimeContext.authenticator.getUser();
-      const projectInfo = await this._runtimeContext.synchronizer.getProjectInfo(path, user.tokenInfo);
+      const projectInfo = this.projectId?.length ?
+        await this._runtimeContext.synchronizer.getProjectInfo({slug: this.projectId}, user.tokenInfo) :
+        await this._runtimeContext.synchronizer.getProjectInfo(path, user.tokenInfo);
+
       return projectInfo?.name ?? '';
     } catch (err) {
       return '';
@@ -117,7 +124,10 @@ class Globals {
     }
 
     try {
-      const policy = await this._runtimeContext.synchronizer.getPolicy(path);
+      const policy = this.projectId?.length ?
+        await this._runtimeContext.synchronizer.getPolicy({slug: this.projectId}) :
+        await this._runtimeContext.synchronizer.getPolicy(path);
+
       return policy;
     } catch (err) {
       return {

--- a/src/utils/globals.ts
+++ b/src/utils/globals.ts
@@ -62,8 +62,8 @@ class Globals {
     return workspace.getConfiguration(SETTINGS.NAMESPACE).get<boolean>(SETTINGS.TELEMETRY_ENABLED);
   }
 
-  get projectId() {
-    return workspace.getConfiguration(SETTINGS.NAMESPACE).get<string>(SETTINGS.PROJECT_ID);
+  get project() {
+    return workspace.getConfiguration(SETTINGS.NAMESPACE).get<string>(SETTINGS.PROJECT);
   }
 
   async setDefaultOrigin() {
@@ -100,8 +100,8 @@ class Globals {
 
     try {
       const user = await this._runtimeContext.authenticator.getUser();
-      const projectInfo = this.projectId?.length ?
-        await this._runtimeContext.synchronizer.getProjectInfo({slug: this.projectId}, user.tokenInfo) :
+      const projectInfo = this.project?.length ?
+        await this._runtimeContext.synchronizer.getProjectInfo({slug: this.project}, user.tokenInfo) :
         await this._runtimeContext.synchronizer.getProjectInfo(path, user.tokenInfo);
 
       return projectInfo?.name ?? '';
@@ -124,8 +124,8 @@ class Globals {
     }
 
     try {
-      const policy = this.projectId?.length ?
-        await this._runtimeContext.synchronizer.getPolicy({slug: this.projectId}) :
+      const policy = this.project?.length ?
+        await this._runtimeContext.synchronizer.getPolicy({slug: this.project}) :
         await this._runtimeContext.synchronizer.getPolicy(path);
 
       return policy;

--- a/src/utils/policy-puller.ts
+++ b/src/utils/policy-puller.ts
@@ -112,8 +112,8 @@ export class PolicyPuller {
       }
 
       const user = await globals.getUser();
-      const policy = globals.projectId?.length ?
-        await this._synchronizer.synchronize({slug: globals.projectId}, user.tokenInfo) :
+      const policy = globals.project?.length ?
+        await this._synchronizer.synchronize({slug: globals.project}, user.tokenInfo) :
         await this._synchronizer.synchronize(root.uri.fsPath, user.tokenInfo);
 
       return policy;

--- a/src/utils/policy-puller.ts
+++ b/src/utils/policy-puller.ts
@@ -112,7 +112,9 @@ export class PolicyPuller {
       }
 
       const user = await globals.getUser();
-      const policy = await this._synchronizer.synchronize(root.uri.fsPath, user.tokenInfo);
+      const policy = globals.projectId?.length ?
+        await this._synchronizer.synchronize({slug: globals.projectId}, user.tokenInfo) :
+        await this._synchronizer.synchronize(root.uri.fsPath, user.tokenInfo);
 
       return policy;
     }, {


### PR DESCRIPTION
This PR fixes #53.

Based on #52 so needs to be merged after that.

![monokle 20231122-1](https://github.com/kubeshop/vscode-monokle/assets/1061942/10ce1627-fe31-4281-8228-cb8c78ee98dd)

## Changes

- Introduced `monokle.projectId` configuration option which can be used to force project from which policy will be fetched.

## Fixes

- None.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test
