### PR TITLE
Initalize validator based on origin config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.5.0",
       "dependencies": {
         "@monokle/parser": "^0.2.0",
-        "@monokle/synchronizer": "^0.12.2",
+        "@monokle/synchronizer": "^0.12.3",
         "@monokle/validation": "^0.31.7",
         "@segment/analytics-node": "^1.1.0",
         "normalize-url": "^4.5.1",
@@ -837,9 +837,9 @@
       }
     },
     "node_modules/@monokle/synchronizer": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/@monokle/synchronizer/-/synchronizer-0.12.2.tgz",
-      "integrity": "sha512-HUFtQmwYcbLQEwfuomWEEU199E/mz8/Xia9BVlPIq/gbWqsxcSHe0fmonNTOuzW8bBGcst376OPuYY/eG2/SWg==",
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/@monokle/synchronizer/-/synchronizer-0.12.3.tgz",
+      "integrity": "sha512-2B9Gdw31v5c3GqIuTfMqTA9nJnwj8jne7+LiiDpQ7B6FOy94UXEuh78H+DTRAO2jReW3NPFV4wBPgFgakiZQGw==",
       "dependencies": {
         "@monokle/types": "*",
         "env-paths": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
   },
   "dependencies": {
     "@monokle/parser": "^0.2.0",
-    "@monokle/synchronizer": "^0.12.2",
+    "@monokle/synchronizer": "^0.12.3",
     "@monokle/validation": "^0.31.7",
     "@segment/analytics-node": "^1.1.0",
     "normalize-url": "^4.5.1",

--- a/src/test/suite-policies/policies.test.ts
+++ b/src/test/suite-policies/policies.test.ts
@@ -52,7 +52,7 @@ suite(`Policies - Remote: ${process.env.ROOT_PATH}`, function () {
 
     await workspace.getConfiguration('monokle').update('enabled', true, ConfigurationTarget.Workspace);
 
-    const configRemote = await waitForValidationConfig(folder, 10000);
+    const configRemote = await waitForValidationConfig(folder, 15000);
 
     ok(configRemote.isValid);
     ok(configRemote.path);
@@ -63,10 +63,10 @@ suite(`Policies - Remote: ${process.env.ROOT_PATH}`, function () {
 
     await commands.executeCommand(COMMANDS.SYNCHRONIZE);
 
-    const configNew = await waitForValidationConfig(folder, 10000);
+    const configNew = await waitForValidationConfig(folder, 15000);
 
     deepEqual(configNew.config, DEFAULT_POLICY);
-  }).timeout(25000);
+  }).timeout(35000);
 });
 
 async function waitForValidationConfig(workspaceFolder: Folder, timeoutMs?: number): Promise<WorkspaceFolderConfig> {

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -255,15 +255,17 @@ export async function getDefaultConfig() {
 }
 
 async function getValidatorInstance() {
-  const {MonokleValidator, ResourceParser, SchemaLoader, RemotePluginLoader, DisabledFixer} = await import('@monokle/validation');
+  const {MonokleValidator, ResourceParser, SchemaLoader, RemotePluginLoader, DisabledFixer, AnnotationSuppressor, FingerprintSuppressor} = await import('@monokle/validation');
+  const {fetchOriginConfig} = await import('@monokle/synchronizer');
 
+  const originConfig = await fetchOriginConfig(globals.origin);
   const parser = new ResourceParser();
-  const loader = new SchemaLoader();
+  const loader = new SchemaLoader(originConfig.schemasOrigin || undefined);
   const validator = new MonokleValidator({
     loader: new RemotePluginLoader(),
     parser,
     schemaLoader: loader,
-    suppressors: [],
+    suppressors: [new AnnotationSuppressor(), new FingerprintSuppressor()],
     fixer: new DisabledFixer(),
   }, {
     plugins: DEFAULT_PLUGIN_MAP,


### PR DESCRIPTION
This PR fixes how validator is initialized to take into account dynamic schema store origin. Part of https://github.com/kubeshop/monokle-saas/issues/2212.

## Changes

- As above.

## Fixes

- As above.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
