### PR TITLE
Migrate to SARIF fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ This extension contributes the following settings:
 
 A core component of Monokle extension and dependency is [`@monokle/validation` library](https://github.com/kubeshop/monokle-core/tree/main/packages/validation).
 
-Monokle extension also uses [SARIF Viewer](https://marketplace.visualstudio.com/items?itemName=MS-SarifVSCode.sarif-viewer) extension as dependency. It should be installed automatically when installing Monokle extension.
+Monokle extension depends on [Monokle SARIF Viewer](https://marketplace.visualstudio.com/items?itemName=Kubeshop.monokle-sarif) extension. It should be installed automatically when installing Monokle extension.
 
 ## Questions and contributing
 

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     }
   },
   "extensionDependencies": [
-    "ms-sarifvscode.sarif-viewer"
+    "kubeshop.monokle-sarif"
   ],
   "scripts": {
     "vscode:prepublish": "rimraf out && npm run esbuild-base -- --minify",

--- a/src/commands/show-panel.ts
+++ b/src/commands/show-panel.ts
@@ -12,7 +12,7 @@ export function getShowPanelCommand() {
       status: 'started'
     });
 
-    const sarifExtension = extensions.getExtension('MS-SarifVSCode.sarif-viewer');
+    const sarifExtension = extensions.getExtension('Kubeshop.monokle-sarif');
 
     if (!sarifExtension.isActive) {
       await sarifExtension.activate();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -63,10 +63,6 @@ async function runActivation(context: ExtensionContext) {
 
   await globals.setDefaultOrigin();
 
-  // Pre-configure SARIF extension (workaround for #16).
-  workspace.getConfiguration('sarif-viewer').update('connectToGithubCodeScanning', 'off');
-  workspace.getConfiguration('sarif-viewer.explorer').update('openWhenNoResults', false);
-
   const statusBarItem = window.createStatusBarItem(StatusBarAlignment.Left, 25);
   statusBarItem.text = STATUS_BAR_TEXTS.DEFAULT;
   statusBarItem.tooltip = getTooltipContentDefault();

--- a/src/test/run-test.ts
+++ b/src/test/run-test.ts
@@ -51,7 +51,7 @@ async function runSuite(
     // Use cp.spawn / cp.exec for custom setup
     spawnSync(
       cliPath,
-      [...args, '--install-extension', 'ms-sarifvscode.sarif-viewer@3.3.8'],
+      [...args, '--install-extension', 'kubeshop.monokle-sarif@0.1.0'],
       {
         encoding: 'utf-8',
         stdio: 'inherit'

--- a/src/utils/sarif-watcher.ts
+++ b/src/utils/sarif-watcher.ts
@@ -47,7 +47,7 @@ export class SarifWatcher {
   }
 
   protected async getSarifApi() {
-    const sarifExtension = extensions.getExtension('MS-SarifVSCode.sarif-viewer');
+    const sarifExtension = extensions.getExtension('Kubeshop.monokle-sarif');
 
     if (!sarifExtension.isActive) {
       await sarifExtension.activate();


### PR DESCRIPTION
This PR migrates to SARIF extension fork (https://github.com/kubeshop/vscode-sarif).

Fixes #16 and fixes #7.

**IMPORTANT**: For now I just released first version of `Kubeshop.monokle-sarif` extension manually from [`f1ames/fix/ui-adjustments`](https://github.com/kubeshop/vscode-sarif/tree/f1ames/fix/ui-adjustments) branch to test how it works. However, before merging and releasing this one we should first proceed with: https://github.com/kubeshop/vscode-sarif/pull/1 and https://github.com/kubeshop/vscode-sarif/pull/2.

## Changes

- As above.

## Fixes

- None.

## Checklist

- [x] tested locally
- [x] added new dependencies
- [ ] updated the docs
- [ ] added a test
