### PR TITLE
Improve error handling

### DIFF
--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -267,7 +267,9 @@ async function getValidatorInstance() {
     schemaLoader: loader,
     suppressors: [new AnnotationSuppressor(), new FingerprintSuppressor()],
     fixer: new DisabledFixer(),
-  }, {
+  });
+
+  await validator.preload({
     plugins: DEFAULT_PLUGIN_MAP,
     settings: DEFAULT_SETTINGS,
   });


### PR DESCRIPTION
This PR fixes some errors in error handling. I found it when testing other changes and in fact we have 3 fixes here:

1. For retrying, disposables where not disposed on errors others than activated check and next initialization would failed due to trying to register same commands (as they need to be disposed). I moved disposable logic to `onFailedAttempt` which is run every after failed attempt.
2. Also `pRetry` does not retry after `TypeError`s so I rethrow any activation errors as generic ones (and why it is important see next point). 
3. The initial issue was that during extension initialization (when validation is run) there was `TypeError: Cannot read properties of undefined (reading 'addSchema')`. When retried, it worked fine (that's way previous point). But more interestingly, this issue is a bit puzzling, it was caused by the fact that when validation was run, it tried to load `prometheus` schema (K8s schema plugin) via `ajv` but `ajv` instance was not initialized yet (thus `Cannot read properties of undefined (reading 'addSchema')` for `this.ajv.addSchema...` erro) from here https://github.com/kubeshop/monokle-core/blob/f1c616d6dec28f74d9ca6005be1a8fdade4fc2b3/packages/validation/src/validators/kubernetes-schema/validator.ts#L118). My assumption was that it should load automatically on first validation run (should it?), if yes it seems there might be an issue in core somewhere (will report a task there then) 🤔  


## Changes

- None.

## Fixes

- As above.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
