### PR TITLE
Validate files on type or save

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,8 +11,10 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
+
 
     runs-on: ${{ matrix.os }}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@monokle/validation": "^0.31.7",
         "@segment/analytics-node": "^1.1.0",
         "normalize-url": "^4.5.1",
+        "p-debounce": "^2.1.0",
         "p-retry": "^4.6.2",
         "uuid": "^9.0.0",
         "yaml": "^2.3.1"
@@ -4327,6 +4328,14 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-debounce": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-debounce/-/p-debounce-2.1.0.tgz",
+      "integrity": "sha512-M9bMt62TTnozdZhqFgs+V7XD2MnuKCaz+7fZdlu2/T7xruI3uIE5CicQ0vx1hV7HIUYF0jF+4/R1AgfOkl74Qw==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/p-limit": {

--- a/package.json
+++ b/package.json
@@ -177,6 +177,7 @@
     "@monokle/validation": "^0.31.7",
     "@segment/analytics-node": "^1.1.0",
     "normalize-url": "^4.5.1",
+    "p-debounce": "^2.1.0",
     "p-retry": "^4.6.2",
     "uuid": "^9.0.0",
     "yaml": "^2.3.1"

--- a/package.json
+++ b/package.json
@@ -119,6 +119,15 @@
           ],
           "default": null,
           "description": "Project which policy will be used for validation. If not set it will deducted based on git repository URL."
+        },
+        "monokle.run": {
+          "type": "string",
+          "enum": [
+            "onSave",
+            "onType"
+          ],
+          "default": "onType",
+          "description": "Run validation on save (onSave) or on type (onType)"
         }
       }
     }

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -1,10 +1,10 @@
 import { getWorkspaceFolders, initializeWorkspaceWatchers } from '../utils/workspace';
 import { canRun } from '../utils/commands';
-import type { FileSystemWatcher } from 'vscode';
+import type { Disposable } from 'vscode';
 import type { RuntimeContext } from '../utils/runtime-context';
 
 export function getWatchCommand(context: RuntimeContext) {
-  const watchers: FileSystemWatcher[] = [];
+  const watchers: Disposable[] = [];
 
   return async () => {
     if (!canRun()) {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -16,12 +16,14 @@ export const SETTINGS = {
   TELEMETRY_ENABLED: 'telemetryEnabled',
   ORIGIN: 'origin',
   PROJECT: 'project',
+  RUN: 'run',
   ENABLED_PATH: 'monokle.enabled',
   CONFIGURATION_PATH_PATH: 'monokle.configurationPath',
   VERBOSE_PATH: 'monokle.verbose',
   TELEMETRY_ENABLED_PATH: 'monokle.telemetryEnabled',
   ORIGIN_PATH: 'monokle.origin',
   PROJECT_PATH: 'monokle.project',
+  RUN_PATH: 'monokle.run',
 };
 
 export const COMMANDS = {
@@ -49,4 +51,9 @@ export const COMMAND_NAMES = {
 export const STATUS_BAR_TEXTS = {
   DEFAULT: '$(circle-outline) Monokle',
   ERROR: '$(warning) Monokle',
+};
+
+export enum RUN_OPTIONS {
+  onSave = 'onSave',
+  onType = 'onType',
 };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -202,6 +202,16 @@ async function runActivation(context: ExtensionContext) {
 
       await commands.executeCommand(COMMANDS.VALIDATE);
     }
+
+    if (event.affectsConfiguration(SETTINGS.RUN_PATH)) {
+      trackEvent('config/change', {
+        status: 'success',
+        name: SETTINGS.RUN,
+        value: String(globals.run),
+      });
+
+      await commands.executeCommand(COMMANDS.WATCH);
+    }
   });
 
   const workspaceWatcher = workspace.onDidChangeWorkspaceFolders(async () => {

--- a/src/test/helpers/suite.ts
+++ b/src/test/helpers/suite.ts
@@ -26,6 +26,12 @@ export async function runForFolders(folders: Folder[], fn: (folder: Folder) => P
   }));
 }
 
+export async function runForFoldersInSequence(folders: Folder[], fn: (folder: Folder) => Promise<void>) {
+  for (const folder of folders) {
+    await fn(folder);
+  }
+}
+
 async function clearStorageDir() {
   return rm(getStorageDir(), { recursive: true, force: true, maxRetries: 3 });
 }

--- a/src/test/run-test.ts
+++ b/src/test/run-test.ts
@@ -22,12 +22,13 @@ type TestWorkspace = {
 type TestFlags = {
   setupRemoteEnv?: boolean;
   skipResultCache?: boolean;
+  validateOnSave?: boolean;
 };
 
 async function runSuite(
   testFile: string,
   workspaces: TestWorkspace[],
-  flags: TestFlags = { setupRemoteEnv: false, skipResultCache: false }
+  flags: TestFlags = { setupRemoteEnv: false, skipResultCache: false, validateOnSave: false }
 ) {
   let currentWorkspace: TestWorkspace | undefined;
 
@@ -95,6 +96,8 @@ async function runSuite(
           MONOKLE_VSC_ENV: 'TEST',
           // eslint-disable-next-line @typescript-eslint/naming-convention
           MONOKLE_TEST_SKIP_RESULT_CACHE: flags.skipResultCache ? 'Y' : undefined,
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          MONOKLE_TEST_VALIDATE_ON_SAVE: flags.validateOnSave ? 'Y' : undefined,
         }
       });
     }
@@ -147,6 +150,7 @@ async function main() {
 
   // Run integration-like tests on multiple, different workspaces (local config).
   await runSuite('./suite-integration/index', workspaces.slice(0, -1), { skipResultCache: true });
+  await runSuite('./suite-integration/index', workspaces.slice(0, -1), { skipResultCache: true, validateOnSave: true });
 
   // Run integration-like tests for remote config separately as it needs different setup.
   await runSuite('./suite-integration/index', [workspaces[3]], { setupRemoteEnv: true });

--- a/src/test/suite-integration/config.test.ts
+++ b/src/test/suite-integration/config.test.ts
@@ -3,7 +3,7 @@ import { getWorkspaceConfig, getWorkspaceFolders } from '../../utils/workspace';
 import { doSetup, doSuiteSetup, doSuiteTeardown } from '../helpers/suite';
 
 suite(`Integration - Config: ${process.env.ROOT_PATH}`, function () {
-  this.timeout(10000);
+  this.timeout(20000);
 
   suiteSetup(async () => {
     await doSuiteSetup();

--- a/src/test/suite-integration/validation.test.ts
+++ b/src/test/suite-integration/validation.test.ts
@@ -8,13 +8,14 @@ import { COMMANDS } from '../../constants';
 import { doSetup, doSuiteSetup, doSuiteTeardown, runForFolders, runForFoldersInSequence } from '../helpers/suite';
 import { assertEmptyValidationResults, assertValidationResults, waitForValidationResults } from '../helpers/asserts';
 
-suite(`Integration - Validation: ${process.env.ROOT_PATH}`, async function () {
+const RUN_ON = process.env.MONOKLE_TEST_VALIDATE_ON_SAVE === 'Y' ? 'onSave' : 'onType';
+
+suite(`Integration - Validation (${RUN_ON}): ${process.env.ROOT_PATH}`, async function () {
   this.timeout(20000);
 
   const fixturesSourceDir = process.env.FIXTURES_SOURCE_DIR;
   const initialResources = parseInt(process.env.WORKSPACE_RESOURCES ?? '0', 10);
   const isDisabled = process.env.WORKSPACE_DISABLED === 'true';
-  const runOn = process.env.MONOKLE_TEST_VALIDATE_ON_SAVE === 'Y' ? 'onSave' : undefined;
 
   suiteSetup(async function () {
     await doSuiteSetup();
@@ -28,10 +29,7 @@ suite(`Integration - Validation: ${process.env.ROOT_PATH}`, async function () {
       const configFile = resolve(join(__dirname, '..', 'tmp', 'fixtures', workspace.getConfiguration('monokle').get('configurationPath')));
       console.log('Setting config file to', configFile);
       await workspace.getConfiguration('monokle').update('configurationPath', configFile, ConfigurationTarget.Workspace);
-
-      if (runOn) {
-        await workspace.getConfiguration('monokle').update('run', runOn, ConfigurationTarget.Workspace);
-      }
+      await workspace.getConfiguration('monokle').update('run', RUN_ON, ConfigurationTarget.Workspace);
     }
   });
 
@@ -99,7 +97,7 @@ suite(`Integration - Validation: ${process.env.ROOT_PATH}`, async function () {
   });
 
   test('Validates resources on change (modification)', async function() {
-    if (initialResources === 0 || runOn === 'onSave') {
+    if (initialResources === 0 || RUN_ON === 'onSave') {
       this.skip();
     }
 

--- a/src/test/suite-integration/validation.test.ts
+++ b/src/test/suite-integration/validation.test.ts
@@ -97,6 +97,11 @@ suite(`Integration - Validation (${RUN_ON}): ${process.env.ROOT_PATH}`, async fu
   });
 
   test('Validates resources on change (modification)', async function() {
+    // // Ignore for now on GHA Windows runner since the test fails for unknown reason.
+    // if (process.env.RUNNER_OS === 'Windows') {
+    //   this.skip();
+    // }
+
     if (initialResources === 0 || RUN_ON === 'onSave') {
       this.skip();
     }
@@ -121,6 +126,8 @@ suite(`Integration - Validation (${RUN_ON}): ${process.env.ROOT_PATH}`, async fu
       edit.replace(uri, range, stringify(asYaml));
       const editResult = await workspace.applyEdit(edit);
 
+      console.warn('Edit result', editResult);
+
       if (!editResult) {
         fail('Failed to modify file');
       }
@@ -130,7 +137,12 @@ suite(`Integration - Validation (${RUN_ON}): ${process.env.ROOT_PATH}`, async fu
     });
   });
 
-  test('Validates resources on change (addition)', async () => {
+  test('Validates resources on change (addition)', async function () {
+    // // Ignore for now on GHA Windows runner since the test fails for unknown reason.
+    // if (process.env.RUNNER_OS === 'Windows') {
+    //   this.skip();
+    // }
+
     const folders = getWorkspaceFolders();
 
     await runForFolders(folders, async (folder) => {

--- a/src/test/suite-integration/validation.test.ts
+++ b/src/test/suite-integration/validation.test.ts
@@ -97,11 +97,6 @@ suite(`Integration - Validation (${RUN_ON}): ${process.env.ROOT_PATH}`, async fu
   });
 
   test('Validates resources on change (modification)', async function() {
-    // // Ignore for now on GHA Windows runner since the test fails for unknown reason.
-    // if (process.env.RUNNER_OS === 'Windows') {
-    //   this.skip();
-    // }
-
     if (initialResources === 0 || RUN_ON === 'onSave') {
       this.skip();
     }
@@ -126,8 +121,6 @@ suite(`Integration - Validation (${RUN_ON}): ${process.env.ROOT_PATH}`, async fu
       edit.replace(uri, range, stringify(asYaml));
       const editResult = await workspace.applyEdit(edit);
 
-      console.warn('Edit result', editResult);
-
       if (!editResult) {
         fail('Failed to modify file');
       }
@@ -138,11 +131,6 @@ suite(`Integration - Validation (${RUN_ON}): ${process.env.ROOT_PATH}`, async fu
   });
 
   test('Validates resources on change (addition)', async function () {
-    // // Ignore for now on GHA Windows runner since the test fails for unknown reason.
-    // if (process.env.RUNNER_OS === 'Windows') {
-    //   this.skip();
-    // }
-
     const folders = getWorkspaceFolders();
 
     await runForFolders(folders, async (folder) => {

--- a/src/utils/file-parser.ts
+++ b/src/utils/file-parser.ts
@@ -62,6 +62,12 @@ export function getCachedResourceCount(filePath: string) {
   return resourcePerFileCache.get(filePath) ?? null;
 }
 
+export function isSubpath(path: Uri, subpath: string) {
+  const subpathUri = Uri.file(subpath);
+
+  return subpathUri.toString().startsWith(path.toString());
+}
+
 async function convertFilesToK8sResources(files: File[]) {
   return (await Promise.all(files.map(async file => {
     const contentRaw = await workspace.fs.readFile(Uri.file(file.path));

--- a/src/utils/file-parser.ts
+++ b/src/utils/file-parser.ts
@@ -1,0 +1,86 @@
+import { RelativePattern, Uri, workspace } from 'vscode';
+import { generateId } from './helpers';
+import { basename } from 'path';
+import { extractK8sResources } from './parser';
+
+export type File = {
+  id: string;
+  name: string;
+  path: string;
+};
+
+export type Resources = Awaited<ReturnType<typeof getResourcesFromFile>>;
+export type Resource = Resources[0];
+
+const ResourcePerFileCache = new Map<string, number>(); // <file path, resource count>
+
+export async function getResourcesFromFolder(folderPath: string): Promise<Resource[]> {
+  const resourceFiles = await findYamlFiles(folderPath);
+  return convertFilesToK8sResources(resourceFiles);
+}
+
+export async function getResourcesFromFile(filePath: string) {
+  const file = {
+    id: generateId(filePath),
+    name: basename(filePath),
+    path: filePath
+  };
+
+  const resources = file ? await convertFilesToK8sResources([file]) : [];
+  return resources;
+}
+
+export async function getResourcesFromFileAndContent(filePath: string, content: string) {
+  const file = {
+    id: generateId(filePath),
+    name: basename(filePath),
+    path: filePath
+  };
+
+  const resources = await extractK8sResources([{
+    id: file.id,
+    path: file.path,
+    content
+  }]);
+
+  return resources;
+}
+
+export function isYamlFile(path: string) {
+  return path.endsWith('.yaml') || path.endsWith('.yml');
+}
+
+async function findYamlFiles(folderPath: string): Promise<File[]> {
+  const files = await workspace.findFiles(new RelativePattern(folderPath, '**/*.{yaml,yml}'));
+
+  return files
+    .map(file => {
+      const fullPath = file.fsPath;
+
+      return {
+        id: generateId(fullPath),
+        name: basename(fullPath),
+        path: fullPath
+      };
+    });
+}
+
+async function convertFilesToK8sResources(files: File[]): Promise<ReturnType<Awaited<typeof extractK8sResources>>> {
+  const filesWithContent = await Promise.all(files.map(async file => {
+    const contentRaw = await workspace.fs.readFile(Uri.file(file.path));
+    const content = Buffer.from(contentRaw.buffer).toString('utf8');
+
+    return {
+      id: file.id,
+      path: file.path,
+      content
+    };
+  }));
+
+  return extractK8sResources(filesWithContent);
+}
+
+
+
+
+

--- a/src/utils/file-parser.ts
+++ b/src/utils/file-parser.ts
@@ -25,6 +25,16 @@ export async function getResourcesFromFolder(folderPath: string): Promise<Resour
   return convertFilesToK8sResources(resourceFiles);
 }
 
+export async function getResourcesFromFolderWithDirty(folderPath: string, dirtyFiles: FileWithContent[]): Promise<Resource[]> {
+  const resourceFiles = await findYamlFiles(folderPath);
+  const allCleanFiles = resourceFiles.filter(file => !dirtyFiles.find(dirtyFile => dirtyFile.path === file.path));
+
+  const cleanResources = await convertFilesToK8sResources(allCleanFiles);
+  const dirtyResources  = (await Promise.all(dirtyFiles.map(async file => getResourcesFromFileAndContent(file.path, file.content)))).flat();
+
+  return [...cleanResources, ...dirtyResources];
+}
+
 export async function getResourcesFromFile(filePath: string) {
   const file = {
     id: generateId(filePath),

--- a/src/utils/file-parser.ts
+++ b/src/utils/file-parser.ts
@@ -58,10 +58,6 @@ export function getFileCacheId(filePath: string) {
   return resourcePerFileCache.get(filePath) ?? null;
 }
 
-export function getCachedResourceCount(filePath: string) {
-  return resourcePerFileCache.get(filePath) ?? null;
-}
-
 export function isSubpath(path: Uri, subpath: string) {
   const subpathUri = Uri.file(subpath);
 

--- a/src/utils/file-parser.ts
+++ b/src/utils/file-parser.ts
@@ -25,16 +25,6 @@ export async function getResourcesFromFolder(folderPath: string): Promise<Resour
   return convertFilesToK8sResources(resourceFiles);
 }
 
-export async function getResourcesFromFolderWithDirty(folderPath: string, dirtyFiles: FileWithContent[]): Promise<Resource[]> {
-  const resourceFiles = await findYamlFiles(folderPath);
-  const allCleanFiles = resourceFiles.filter(file => !dirtyFiles.find(dirtyFile => dirtyFile.path === file.path));
-
-  const cleanResources = await convertFilesToK8sResources(allCleanFiles);
-  const dirtyResources  = (await Promise.all(dirtyFiles.map(async file => getResourcesFromFileAndContent(file.path, file.content)))).flat();
-
-  return [...cleanResources, ...dirtyResources];
-}
-
 export async function getResourcesFromFile(filePath: string) {
   const file = {
     id: generateId(filePath),

--- a/src/utils/globals.ts
+++ b/src/utils/globals.ts
@@ -66,6 +66,10 @@ class Globals {
     return workspace.getConfiguration(SETTINGS.NAMESPACE).get<string>(SETTINGS.PROJECT);
   }
 
+  get run() {
+    return workspace.getConfiguration(SETTINGS.NAMESPACE).get<string>(SETTINGS.RUN);
+  }
+
   async setDefaultOrigin() {
     const {DEFAULT_ORIGIN} = await import('@monokle/synchronizer');
     this._defaultOrigin = DEFAULT_ORIGIN;

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -5,6 +5,10 @@ const logger = {
     logger.debug && console.log('Monokle:', message, ...optionalParams);
   },
 
+  warn: (message?: any, ...optionalParams: any[]) => {
+    logger.debug && console.warn('Monokle:', message, ...optionalParams);
+  },
+
   error: (message?: any, ...optionalParams: any[]) => {
     logger.debug && console.error('Monokle:', message, ...optionalParams);
   },

--- a/src/utils/sarif-watcher.ts
+++ b/src/utils/sarif-watcher.ts
@@ -14,6 +14,17 @@ export class SarifWatcher {
     }
   }
 
+  async addMany(uris: Uri[]) {
+    const sarifApi = await this.getSarifApi();
+    const added = uris.filter(u => !this._uris.find(u2 => u2.path === u.path));
+
+    this._uris = [...this._uris, ...added];
+
+    if (added.length) {
+      return sarifApi.openLogs(added);
+    }
+  }
+
   async remove(uri: Uri) {
     const index = this._uris.findIndex(u => u.path === uri.path);
 

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -78,10 +78,14 @@ export async function validateFolder(root: Folder): Promise<Uri | null> {
 export async function validateFolderWithDirtyFiles(root: Folder, dirtyResources: Resource[], dirtyFiles: readonly Uri[]): Promise<Uri | null> {
   const resources = await getResourcesFromFolder(root.uri.fsPath);
   const dirtyFilesPaths = dirtyFiles.map(file => file.toString());
+
+  if (dirtyFilesPaths.length === 0) {
+    return validateResourcesFromFolder(resources, root);
+  }
+
   const unchangedResources = resources.filter(resource => {
     return !dirtyFilesPaths.includes(Uri.file(resource.filePath).toString());
   });
-
   return validateResourcesFromFolder([...unchangedResources, ...dirtyResources], root);
 }
 

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -10,7 +10,7 @@ import { trackEvent } from './telemetry';
 import { getResultCache } from './result-cache';
 import logger from '../utils/logger';
 import globals from './globals';
-import type { Folder } from './workspace';
+import type { Folder, Resource } from './workspace';
 
 export type ConfigurableValidator = {
   parser: any;
@@ -73,7 +73,7 @@ export async function validateFolder(root: Folder): Promise<Uri | null> {
   return validateResourcesFromFolder(resources, root);
 }
 
-export async function validateResourcesFromFolder(resources: any, root: Folder, incremental = false): Promise<Uri | null> {
+export async function validateResourcesFromFolder(resources: Resource[], root: Folder, incremental = false): Promise<Uri | null> {
   trackEvent('workspace/validate', {
     status: 'started',
   });
@@ -112,9 +112,16 @@ export async function validateResourcesFromFolder(resources: any, root: Folder, 
 
   logger.log(root.name, 'validator', validator);
 
+  let incrementalParam: {resourceIds: string[]} | undefined = undefined;
+  if (incremental) {
+    incrementalParam = {
+      resourceIds: resources.map(resource => resource.id)
+    };
+  }
+
   const result = await validator.validate({
     resources: resources,
-    incremental,
+    incremental: incrementalParam
   });
 
   logger.log(root.name, 'result', result);

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -76,7 +76,6 @@ export async function validateFolder(root: Folder): Promise<Uri | null> {
 export async function validateResourcesFromFolder(resources: any, root: Folder, incremental = false): Promise<Uri | null> {
   trackEvent('workspace/validate', {
     status: 'started',
-    // incremental,
   });
 
   if(!resources.length) {

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -75,10 +75,11 @@ export async function validateFolder(root: Folder): Promise<Uri | null> {
   return validateResourcesFromFolder(resources, root);
 }
 
-export async function validateFolderWithDirtyFiles(root: Folder, dirtyResources: Resource[], dirtyFiles: string[]): Promise<Uri | null> {
+export async function validateFolderWithDirtyFiles(root: Folder, dirtyResources: Resource[], dirtyFiles: readonly Uri[]): Promise<Uri | null> {
   const resources = await getResourcesFromFolder(root.uri.fsPath);
+  const dirtyFilesPaths = dirtyFiles.map(file => file.toString());
   const unchangedResources = resources.filter(resource => {
-    return !dirtyFiles.includes(resource.filePath);
+    return !dirtyFilesPaths.includes(Uri.file(resource.filePath).toString());
   });
 
   return validateResourcesFromFolder([...unchangedResources, ...dirtyResources], root);

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -10,7 +10,8 @@ import { trackEvent } from './telemetry';
 import { getResultCache } from './result-cache';
 import logger from '../utils/logger';
 import globals from './globals';
-import type { Folder, Resource } from './workspace';
+import type { Folder } from './workspace';
+import type { Resource } from './file-parser';
 
 export type ConfigurableValidator = {
   parser: any;

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -8,10 +8,11 @@ import { VALIDATION_FILE_SUFFIX, DEFAULT_CONFIG_FILE_NAME, TMP_POLICY_FILE_SUFFI
 import { getInvalidConfigError } from './errors';
 import { trackEvent } from './telemetry';
 import { getResultCache } from './result-cache';
+import { getResourcesFromFolderWithDirty } from './file-parser';
 import logger from '../utils/logger';
 import globals from './globals';
 import type { Folder } from './workspace';
-import type { Resource } from './file-parser';
+import type { FileWithContent, Resource } from './file-parser';
 
 export type ConfigurableValidator = {
   parser: any;
@@ -71,6 +72,11 @@ export async function getValidator(validatorId: string, config?: any) {
 
 export async function validateFolder(root: Folder): Promise<Uri | null> {
   const resources = await getWorkspaceResources(root);
+  return validateResourcesFromFolder(resources, root);
+}
+
+export async function validateFolderWithDirtyFiles(root: Folder, dirtyFiles: FileWithContent[]): Promise<Uri | null> {
+  const resources = await getResourcesFromFolderWithDirty(root.uri.fsPath, dirtyFiles);
   return validateResourcesFromFolder(resources, root);
 }
 

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -173,6 +173,7 @@ export async function getValidationResult(fileName: string) {
     const resultsAsString = await readFile(filePath, 'utf8');
     return JSON.parse(resultsAsString);
   } catch (e) {
+    console.error('Error in getValidationResult', e);
     return null;
   }
 }

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -69,11 +69,15 @@ export async function getValidator(validatorId: string, config?: any) {
 }
 
 export async function validateFolder(root: Folder): Promise<Uri | null> {
+  const resources = await getWorkspaceResources(root);
+  return validateResourcesFromFolder(resources, root);
+}
+
+export async function validateResourcesFromFolder(resources: any, root: Folder, incremental = false): Promise<Uri | null> {
   trackEvent('workspace/validate', {
     status: 'started',
+    // incremental,
   });
-
-  const resources = await getWorkspaceResources(root);
 
   if(!resources.length) {
     trackEvent('workspace/validate', {
@@ -111,6 +115,7 @@ export async function validateFolder(root: Folder): Promise<Uri | null> {
 
   const result = await validator.validate({
     resources: resources,
+    incremental,
   });
 
   logger.log(root.name, 'result', result);
@@ -234,14 +239,14 @@ export async function removeConfig(path: string, fileName: string) {
   }
 }
 
-export async function clearResourceCache(root: Folder, resourceId: string) {
+export async function clearResourceCache(root: Folder, resourceIds: string[]) {
   const validatorItem = VALIDATORS.get(root.id);
   const parser = validatorItem?.validator?.parser;
 
-  logger.log('clearResourceCache', !!parser, root.name, resourceId);
+  logger.log('clearResourceCache', !!parser, root.name, resourceIds);
 
   if (parser) {
-      parser.clear([resourceId]);
+      parser.clear(resourceIds);
   }
 }
 

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -174,7 +174,6 @@ export async function getValidationResult(fileName: string) {
     const resultsAsString = await readFile(filePath, 'utf8');
     return JSON.parse(resultsAsString);
   } catch (e) {
-    console.error('Error in getValidationResult', e);
     return null;
   }
 }

--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -105,7 +105,7 @@ export function initializeWorkspaceWatchers(workspaceFolders: Folder[], context:
 
   if (globals.run === RUN_OPTIONS.onType) {
     const onDidChangeTextDocumentListener = async (e: TextDocumentChangeEvent) => {
-      console.warn('Validating: Document changed', e.document.uri.fsPath, e, e.document.getText());
+      logger.log('Validating: Document changed', e.document.uri.fsPath, e, e.document.getText());
       await runFileWithContentValidation(e.document.uri, e.document.getText(), workspaceFolders, context);
     };
     const debouncedListener = pDebounce(onDidChangeTextDocumentListener, ON_TYPE_DEBOUNCE_MS);
@@ -168,7 +168,7 @@ async function runFileWithContentValidation(file: Uri, content: string,  workspa
   const resources = await getResourcesFromFileAndContent(file.path, content);
   const currentFileResourceId = getFileCacheId(file.fsPath);
 
-  console.log(
+  logger.log(
     `runFileWithContentValidation, path: ${file.fsPath}, incremental: ${previousFileResourceId === currentFileResourceId}, count: ${resources.length}`
   );
 
@@ -256,7 +256,7 @@ async function validateResources(
     });
   }
 
-  console.log('validateResources', resources, workspaceFolders, resourcesByWorkspace, options);
+  logger.log('validateResources', resources, workspaceFolders, resourcesByWorkspace, options);
 
   let resultUris: Uri[] = [];
   // 1. If incremental, validate only changed files.

--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -197,9 +197,9 @@ async function runFilesValidation(files: readonly Uri[], workspaceFolders: Folde
 
   let useIncremental = incremental;
 
-  const resources = (await Promise.all(files.map(file => {
+  const resources = (await Promise.all(files.map(async (file) => {
     const previousFileResourceId = getFileCacheId(file.fsPath);
-    const resources = getResourcesFromFile(file.path);
+    const resources = await getResourcesFromFile(file.path);
     const currentFileResourceId = getFileCacheId(file.fsPath);
 
     useIncremental = useIncremental && previousFileResourceId === currentFileResourceId;
@@ -211,7 +211,11 @@ async function runFilesValidation(files: readonly Uri[], workspaceFolders: Folde
     `runFilesValidation, paths: ${files.map(f => f.path).join(';')}, incremental: ${useIncremental}, count: ${resources.length}`
   );
 
-  await validateResources(resources, workspaceFolders, context, { incremental: useIncremental });
+  if (useIncremental) {
+    await validateResources(resources, workspaceFolders, context, { incremental: useIncremental });
+  } else {
+    await validateResources(resources, workspaceFolders, context, { incremental: useIncremental, dirtyFiles: yamlFiles });
+  }
 
   context.isValidating = false;
 }

--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -29,7 +29,7 @@ export type WorkspaceFolderConfig = {
   remoteProjectName?: string;
 };
 
-type Resource = Awaited<ReturnType<typeof getResourceFromPath>>;
+export type Resource = Awaited<ReturnType<typeof getResourceFromPath>>;
 
 const ON_TYPE_DEBOUNCE_MS = 250;
 const ON_SAVE_DEBOUNCE_MS = 250;
@@ -134,9 +134,10 @@ export function initializeWorkspaceWatchers(workspaceFolders: Folder[], context:
     const affectedFiles = new Map<string, Uri>();
 
     const onDidSaveTextDocumentListener = async () => {
-      logger.log('Validating: Documents saved', affectedFiles);
-
       const savedFiles = Array.from(affectedFiles.values());
+
+      logger.log('Validating: Documents saved', savedFiles);
+
       affectedFiles.clear();
       await runFilesValidation(savedFiles, workspaceFolders, context, true);
     };

--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -1,9 +1,9 @@
 import { RelativePattern, Uri, workspace } from 'vscode';
 import { basename, join, normalize } from 'path';
 import { stat } from 'fs/promises';
-import { clearResourceCache, getDefaultConfig, getValidationResultPath, readConfig, validateFolder } from './validation';
+import { clearResourceCache, getDefaultConfig, readConfig, validateFolder } from './validation';
 import { generateId } from './helpers';
-import { SETTINGS, DEFAULT_CONFIG_FILE_NAME } from '../constants';
+import { SETTINGS, DEFAULT_CONFIG_FILE_NAME, RUN_OPTIONS } from '../constants';
 import { extractK8sResources } from './parser';
 import logger from '../utils/logger';
 import globals from '../utils/globals';
@@ -27,6 +27,8 @@ export type WorkspaceFolderConfig = {
   fileName?: string;
   remoteProjectName?: string;
 };
+
+type Resource = Awaited<ReturnType<typeof getResourceFromPath>>;
 
 export function getWorkspaceFolders(): Folder[] {
   return [...(workspace.workspaceFolders ?? [])]
@@ -108,137 +110,103 @@ export async function getWorkspaceConfig(workspaceFolder: Folder): Promise<Works
 
 export function initializeWorkspaceWatchers(workspaceFolders: Folder[], context: RuntimeContext) {
   const watchers: Disposable[] = [];
-  const validators: Record<string, (filePath: string) => Promise<void>> = {};
 
-  for (const folder of workspaceFolders) {
-    const pattern = new RelativePattern(folder.uri.fsPath, '**/*.{yaml,yml}');
-    const watcher = workspace.createFileSystemWatcher(pattern);
-    const resultFile = getValidationResultPath(folder.id);
-
-    watchers.push(watcher);
-
-    const resetResourceCache = async (filePath: string) => {
-      const resourceId = await getResourceIdFromPath(folder, filePath);
-
-      if (!resourceId) {
-        return;
-      }
-
-      return clearResourceCache(folder, resourceId);
-    };
-
-    const revalidateFolder = async () => {
-      logger.log('revalidateFolder', folder);
-
-      context.isValidating = true;
-
-      const uri = await validateFolder(folder);
-      if (uri) {
-        await context.sarifWatcher.add(Uri.file(resultFile));
-      } else {
-        await context.sarifWatcher.remove(Uri.file(resultFile));
-      }
-
-      context.isValidating = false;
-    };
-
-    validators[folder.id] = async (filePath: string) => {
-      await resetResourceCache(filePath);
-      await revalidateFolder();
-    };
-
-    watcher.onDidChange(async (uri) => {
-      logger.log(`File ${uri.fsPath} has been changed`);
-      await resetResourceCache(uri.fsPath);
-      await revalidateFolder();
+  if (globals.run === RUN_OPTIONS.onType) {
+    const documentWatcher = workspace.onDidChangeTextDocument(async (e) => {
+      logger.log('Validating: Document changed', e.document.uri.fsPath, e, e.document.getText());
+      // @TODO should be deobounced too
+      // @TODO this should run incremental validation with only changed file
+      await runFileWithContentValidation(e.document.uri, e.document.getText(), workspaceFolders, context);
     });
 
-    watcher.onDidCreate(async (uri) => {
-      logger.log(`File ${uri.fsPath} has been created`);
-      await revalidateFolder();
-    });
-
-    watcher.onDidDelete(async (uri) => {
-      logger.log(`File ${uri.fsPath} has been deleted`);
-      await revalidateFolder();
-    });
+    watchers.push(documentWatcher);
   }
 
-  const documentWatcher = workspace.onDidChangeTextDocument(async (e) => {
-    const filePath = e.document.uri.fsPath;
-    const ownerWorkspace = workspaceFolders.find(folder => filePath.startsWith(folder.uri.fsPath));
+  if (globals.run === RUN_OPTIONS.onSave) {
+    const documentSavedWatcher = workspace.onDidSaveTextDocument(async (e) => {
+      // @TODO
+      // There can be multiple events at once, for example I have save on focus plugin,
+      // this means I can edit multiple files and when VSC window loses focus it will save all
+      // which will trigger multiple events at once.
+      // I think we should group them and run validation only once with debounce/throttling.
+      // @TODO this should run incremental validation with only changed files
+      logger.log('Validating: Document saved', e.uri.fsPath);
+      await runFilesValidation([e.uri], workspaceFolders, context);
+    });
 
-    if (validators[ownerWorkspace.id]) {
-      await validators[ownerWorkspace.id](filePath);
-    }
-  });
+    const documentCreatedWatcher = workspace.onDidCreateFiles(async (e) => {
+      logger.log('Validating: Documents created', e.files.map(file => file.fsPath));
+      await runFilesValidation(e.files, workspaceFolders, context);
+    });
 
-  watchers.push(documentWatcher);
+    const documentDeletedWatcher = workspace.onDidDeleteFiles(async (e) => {
+      logger.log('Validating: Documents deleted', e.files.map(file => file.fsPath));
+      await runFilesValidation(e.files, workspaceFolders, context);
+    });
+
+    watchers.push(documentSavedWatcher, documentCreatedWatcher, documentDeletedWatcher);
+  }
+
+  // @TODO create / delete watchers should be always there
 
   return watchers;
+}
 
-  // On change we don't want to run whole validate command again (unless this is very first run @TODO).
-  // Because:
-  // The sarif output file is already there, initiated with sarif..openLogs
-  // This means sarif ext has a watcher on this file, whenever it changes it will update the sarif view.
-  // So we just need to update the sarif output file, based on new validation result.
-  // For that:
-  // - match changes with the workspace folder
-  // - get validator for each workspace folder
-  // - run validate command for each workspace folder (incremental?)
-  // - save validation results to sarif output file
-  // - sarif should reload automatically
-  return workspaceFolders.map((folder) => {
-    const pattern = new RelativePattern(folder.uri.fsPath, '**/*.{yaml,yml}');
-    const watcher = workspace.createFileSystemWatcher(pattern);
-    const resultFile = getValidationResultPath(folder.id);
+async function runFileWithContentValidation(file: Uri, content: string,  workspaceFolders: Folder[], context: RuntimeContext) {
+  context.isValidating = true;
 
-    const revalidateFolder = async () => {
-      logger.log('revalidateFolder', folder);
+  // @TODO filter out not yaml files
 
-      context.isValidating = true;
+  const resource = await getResourceFromPathAndContent(file.path, content);
+  const resultUris = await validateResources([resource], workspaceFolders);
 
-      const uri = await validateFolder(folder);
-      if (uri) {
-        await context.sarifWatcher.add(Uri.file(resultFile));
-      } else {
-        await context.sarifWatcher.remove(Uri.file(resultFile));
-      }
+  await context.sarifWatcher.replace(resultUris);
 
-      context.isValidating = false;
+  context.isValidating = false;
+}
+
+async function runFilesValidation(files: readonly Uri[], workspaceFolders: Folder[], context: RuntimeContext) {
+  context.isValidating = true;
+
+  // @TODO filter out not yaml files
+
+  const resources = (await Promise.all(files.map(file => getResourceFromPath(file.path)))).filter(Boolean);
+  const resultUris = await validateResources(resources, workspaceFolders);
+
+  await context.sarifWatcher.replace(resultUris);
+
+  context.isValidating = false;
+}
+
+// For each file
+// - map it to resource
+// - group by workspace folder
+// - clear its validation cache (it requires workspace folder and resource id)
+// - run workspace validation
+async function validateResources(resources: Resource[], workspaceFolders: Folder[]) {
+  const resourcesByWorkspace: Record<string, {workspace: Folder, resources: any}> = resources.reduce((acc, resource) => {
+    const ownerWorkspace = workspaceFolders.find(folder => resource.filePath.startsWith(folder.uri.fsPath));
+    if (!ownerWorkspace) {
+      return acc;
+    }
+
+    const workspaceData = acc[ownerWorkspace.id] ?? { workspace: ownerWorkspace, resources: [] };
+    workspaceData.resources.push(resource);
+
+    return {
+      ...acc,
+      [ownerWorkspace.id]: workspaceData,
     };
+  }, {});
 
-    const resetResourceCache = async (filePath: string) => {
-      const resourceId = await getResourceIdFromPath(folder, filePath);
+  const resultUris = await Promise.all(Object.values(resourcesByWorkspace).map(async workspaceData => {;
+    await clearResourceCache(workspaceData.workspace, resources.map(resource => resource.id));
+    return await validateFolder(workspaceData.workspace);
+  }));
 
-      if (!resourceId) {
-        return;
-      }
+  // TODO make sure we have uri for all existing workspaces?
 
-      return clearResourceCache(folder, resourceId);
-    };
-
-    watcher.onDidChange(async (uri) => {
-      logger.log(`File ${uri.fsPath} has been changed`);
-      await resetResourceCache(uri.fsPath);
-      await revalidateFolder();
-    });
-
-    watcher.onDidCreate(async (uri) => {
-      logger.log(`File ${uri.fsPath} has been created`);
-      await revalidateFolder();
-    });
-
-    watcher.onDidDelete(async (uri) => {
-      logger.log(`File ${uri.fsPath} has been deleted`);
-      await revalidateFolder();
-    });
-
-    return watcher;
-  });
-
-  // workspace validators
-  // onchange -> match to workspace, run workspace validation
+  return resultUris;
 }
 
 async function findYamlFiles(folderPath: string): Promise<File[]> {
@@ -250,7 +218,7 @@ async function findYamlFiles(folderPath: string): Promise<File[]> {
 
       return {
         id: generateId(fullPath),
-        name: basename(file.fsPath),
+        name: basename(fullPath),
         path: fullPath
       };
     });
@@ -286,10 +254,35 @@ async function getWorkspaceLocalConfig(workspaceFolder: Folder) {
   return readConfig(configPath);
 }
 
-async function getResourceIdFromPath(folder: Folder, path: string) {
-  const files = await findYamlFiles(folder.uri.fsPath);
-  const file = files.find(file => normalize(file.path) === normalize(path));
-  const resources = file ? await convertFilesToK8sResources([file]) : [];
+async function getResourceFromPath(path: string) {
+  const file = {
+    id: generateId(path),
+    name: basename(path),
+    path: path
+  };
 
-  return resources.pop()?.id ?? null;
+  // @TODO handle invalid (non-parsable) resources
+  // For now we return null which results in 0 validation files and then those are rmeove from sarfiwatcher via replace, we don't want this
+  // OTOH we should cleanup when workspaces list changes (folder added/removed) - but I guess only then?
+  const resources = file ? await convertFilesToK8sResources([file]) : [];
+  return resources.pop() ?? null;
+}
+
+async function getResourceFromPathAndContent(path: string, content: string) {
+  const file = {
+    id: generateId(path),
+    name: basename(path),
+    path: path
+  };
+
+  const resources = await extractK8sResources([{
+    id: file.id,
+    path: file.path,
+    content
+  }]);
+
+  // @TODO handle invalid (non-parsable) resources
+  // For now we return null which results in 0 validation files and then those are rmeove from sarfiwatcher via replace, we don't want this
+  // OTOH we should cleanup when workspaces list changes (folder added/removed) - but I guess only then?
+  return resources.pop() ?? null;
 }

--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -5,7 +5,7 @@ import { stat } from 'fs/promises';
 import { clearResourceCache, getDefaultConfig, readConfig, validateFolder, validateFolderWithDirtyFiles, validateResourcesFromFolder } from './validation';
 import { generateId } from './helpers';
 import { SETTINGS, DEFAULT_CONFIG_FILE_NAME, RUN_OPTIONS } from '../constants';
-import { getFileCacheId, getResourcesFromFile, getResourcesFromFileAndContent, getResourcesFromFolder, isYamlFile } from './file-parser';
+import { getFileCacheId, getResourcesFromFile, getResourcesFromFileAndContent, isYamlFile } from './file-parser';
 import logger from '../utils/logger';
 import globals from '../utils/globals';
 import type { WorkspaceFolder, Disposable, TextDocument, TextDocumentChangeEvent } from 'vscode';
@@ -147,7 +147,7 @@ export function initializeWorkspaceWatchers(workspaceFolders: Folder[], context:
 
   const documentDeletedWatcher = workspace.onDidDeleteFiles(async (e) => {
     logger.log('Validating: Documents deleted', e.files.map(file => file.fsPath));
-    await runFilesValidation(e.files, workspaceFolders, context, false);
+    await validateResources([], workspaceFolders, context, { incremental: false, dirtyFiles: e.files.map(file => file.fsPath) });
   });
 
   watchers.push(documentCreatedWatcher, documentDeletedWatcher);

--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -176,7 +176,13 @@ async function runFileWithContentValidation(file: Uri, content: string,  workspa
 
   // We use incremental validation only when there are same resources in the file (thus previousFileResourceId === currentFileResourceId).
   // @TODO even if not incremental we need to pass dirty content to validation so it's not read from disk again (as it hasn't been saved yet)
-  await validateResources(resources, workspaceFolders, context, previousFileResourceId === currentFileResourceId);
+  const incremental = previousFileResourceId === currentFileResourceId;
+  if (incremental) {
+    await validateResources(resources, workspaceFolders, context, true);
+  } else {
+    await validateResources(resources, workspaceFolders, context, false); // @TODO pass file with content
+  }
+
 
   context.isValidating = false;
 }

--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -105,7 +105,7 @@ export function initializeWorkspaceWatchers(workspaceFolders: Folder[], context:
 
   if (globals.run === RUN_OPTIONS.onType) {
     const onDidChangeTextDocumentListener = async (e: TextDocumentChangeEvent) => {
-      logger.log('Validating: Document changed', e.document.uri.fsPath, e, e.document.getText());
+      console.warn('Validating: Document changed', e.document.uri.fsPath, e, e.document.getText());
       await runFileWithContentValidation(e.document.uri, e.document.getText(), workspaceFolders, context);
     };
     const debouncedListener = pDebounce(onDidChangeTextDocumentListener, ON_TYPE_DEBOUNCE_MS);
@@ -168,7 +168,7 @@ async function runFileWithContentValidation(file: Uri, content: string,  workspa
   const resources = await getResourcesFromFileAndContent(file.path, content);
   const currentFileResourceId = getFileCacheId(file.fsPath);
 
-  logger.log(
+  console.log(
     `runFileWithContentValidation, path: ${file.fsPath}, incremental: ${previousFileResourceId === currentFileResourceId}, count: ${resources.length}`
   );
 
@@ -255,6 +255,8 @@ async function validateResources(
       }
     });
   }
+
+  console.log('validateResources', resources, workspaceFolders, resourcesByWorkspace, options);
 
   let resultUris: Uri[] = [];
   // 1. If incremental, validate only changed files.


### PR DESCRIPTION
This PR fixes #49. It allows to configure if resources should be validated on save or on type (which is default one).

## Changes

- Introduced `monokle.run` with `onType` and `onSave` options (`onType` by default).
- Reworked how extension watches for file changes. Before it was generic (provided by VSCode API) watcher and now dedicated events are used - `workspace.onDidChangeTextDocument` (onType), `workspace.onDidSaveTextDocument` (onSave), `workspace.onDidCreateFiles` and `workspace.onDidDeleteFiles` (for both). The **important difference is that, generic watcher also reacted when files were changed by 3rd-party processes, while those listeners reacts only for changes triggered by VSC (or it's API)** - still I think it's reasonable in context of better efficiency we get from dedicated listeners.
- Made use of `MonokleValidator` `incremental` flag - we know exactly which file changes (and it's dirty content if it's onType related) so incremental flag can be used in multiple cases.
  - There is important case to have in mind, incremental works by providing `resourceId` and for change events we get files. Each file can have multiple resources. And for example when one resource definition is removed from such file we can't use incremental (because we want to tell validator to revalidate removed resource which id we don't have). In such cases incremental is not used.
- What was tricky (or I just didn't anticipated it 😅), is that for `onType` we need to get dirty file content (as it is not saved yet) and pass it to validator - before, we always read file content for validation from disk.
- From code perspective it wasn't such a big rework but conceptually it was, and I think it's not fully there with this solution (see remarks below).

See API docs for reference - https://code.visualstudio.com/api/references/vscode-api.

## Fixes

- As above.

## Remarks

I'm not fully happy with the solution. From functional and performance-related perspective I think it's really good improvement.  For example, before, for every file saved, entire workspace directory was read to get files via globing `**/**.yaml` (even to get single file content 😓🙈), so now with dedicated listeners it's much better.
But from the code and architecture perspective after spending some time with this and all the edge cases - where you need to validate dirty files, keeping track of resources in the file to determine if use incremental validation, local config can get dirty, etc. it become complex in the existing form.
I think the better approach would be keeping and abstract "living" file list with all the manifests and their content which reacts on file changes and stores most recent content (dirty or read from fs) and then always validate using this abstraction instead of directly reading from fs when validating. But it will be another 2-3 days of work and since I realized this a bit too early, didn't want to spend more time on refactoring working solution.

## Checklist

- [x] tested locally
- [x] added new dependencies
- [ ] updated the docs
- [x] added a test
