### PR TITLE
Manifests scanning performance improvements

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -239,11 +239,15 @@ async function runActivation(context: ExtensionContext) {
   }
 
   await initTelemetry();
-  await runtimeContext.refreshPolicyPuller();
-  await commands.executeCommand(COMMANDS.VALIDATE);
-  await commands.executeCommand(COMMANDS.WATCH);
 
   logger.log('Extension activated...', globals.asObject());
+
+  // Defer initial validation so it doesn't block the activation.
+  setTimeout(async () => {
+    await runtimeContext.refreshPolicyPuller();
+    await commands.executeCommand(COMMANDS.VALIDATE);
+    await commands.executeCommand(COMMANDS.WATCH);
+  }, 10);
 }
 
 async function configureRuntimeContext(runtimeContext: RuntimeContext) {

--- a/src/utils/file-parser.ts
+++ b/src/utils/file-parser.ts
@@ -89,7 +89,10 @@ async function extractResources(file: FileWithContent) {
 }
 
 async function findYamlFiles(folderPath: string): Promise<File[]> {
-  const files = await workspace.findFiles(new RelativePattern(folderPath, '**/*.{yaml,yml}'));
+  const files = await workspace.findFiles(
+    new RelativePattern(folderPath, '**/*.{yaml,yml}'),
+    new RelativePattern(folderPath, '**/node_modules/**')
+  );
 
   return files
     .map(file => {

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -2,15 +2,15 @@ const logger = {
   debug: false,
 
   log: (message?: any, ...optionalParams: any[]) => {
-    logger.debug && console.log('Monokle:', message, ...optionalParams);
+    logger.debug && console.log(`${(new Date()).toISOString()}: Monokle:`, message, ...optionalParams);
   },
 
   warn: (message?: any, ...optionalParams: any[]) => {
-    logger.debug && console.warn('Monokle:', message, ...optionalParams);
+    logger.debug && console.warn(`${(new Date()).toISOString()}: Monokle:`, message, ...optionalParams);
   },
 
   error: (message?: any, ...optionalParams: any[]) => {
-    logger.debug && console.error('Monokle:', message, ...optionalParams);
+    logger.debug && console.error(`${(new Date()).toISOString()}: Monokle:`, message, ...optionalParams);
   },
 };
 


### PR DESCRIPTION
This PR fixes https://github.com/kubeshop/monokle-saas/issues/2258.

TL;DR: There are not many changes here, since the main issue was solved by recent PR. See **Analysis** below.

## Changes

- Added datetime to logs to see better what takes time.
- Manifests scanning now ignores `node_modules` dirs by default. Since adding proper support for `.gitignore`s is not trivial, I think this is a good enough solution for now (especially that it wasn't the cause here, at least not main one). For gitignores, I extracted separate issue, see reasoning behind this in the issue itself - https://github.com/kubeshop/vscode-monokle/issues/71.

## Fixes

- Deferred initial validation instead of keeping it a part of activation logic (https://github.com/kubeshop/vscode-monokle/pull/68/commits/cf85d680a4f0c5f43bb8ce074479ab383c5b303d). This way activation time is shorter (you don't see `Activating extensions` status in VSC for so long) - especially that reading yamls from workspace (which is a part of validation) takes, like 10 - 20 seconds (see below).

## Analysis

### A bit on files finding

What is used now for scanning for manifests is native [`workspace.findeFiles`](https://code.visualstudio.com/api/references/vscode-api#3250). It takes into account files ignored in VSC via `files.exclude` but does not look on `.gitignore`.

Now measuring times for `monokle-saas` repo, it seems not finding files but parsing them takes most time:
![image](https://github.com/kubeshop/vscode-monokle/assets/1061942/6852d586-f164-49b1-acb7-36bc45bcd7ff)
and interestingly we got 50 resources from 837 files, which means most files are not K8s resources (I quickly check and just by ignoring `node_modules` we get to 137 files and less than 5 seconds).

Still the initial issue is not about a time, but resources. And finding yamls is the only place we do any find with globbing so this is a solid candidate for triggering resource intensive `rg` calls (and first thing to check is if excluding large dirs, like node_modules, makes it less CPU demanding).

### On `rg`

I tested how `rg` behaves when switching branches with `monokle-saas` repo (from some old feature branch to main). But what I noticed is that it mostly happen when there are lots changes to pull, when switching to new branch for the first time. So the procedure for me was:

1. Install specific extension version (from marketplace or local build).
2. Open local test repo in VSCode.
1. Switch to `main` branch (with latest changes) in local test repo. 
3. Restart VSCode.
4. Switch to new branch/tag (old one, which is not checkouted locally).
5. Run `Monokle: Validate`.

**0.6.5**

First, with current `0.6.5` version and results are similar as mentioned in initial issue, it goes wild a bit (output from `atop` with 1s interval, each screenshot is next snapshot):

![image](https://github.com/kubeshop/vscode-monokle/assets/1061942/0b3333f7-38cb-4554-b91d-b87863d73c7c)
![image](https://github.com/kubeshop/vscode-monokle/assets/1061942/03499526-6d0c-4c87-a2ee-583d0c99407f)
![image](https://github.com/kubeshop/vscode-monokle/assets/1061942/d59c381e-9503-49c5-b3bc-e4413b8c1d3c)
![image](https://github.com/kubeshop/vscode-monokle/assets/1061942/f982c382-39c0-4336-8839-1aa17877cd66)

**With file watcher changes**

There were significant changes how files are processed in https://github.com/kubeshop/vscode-monokle/pull/62. So I also tested with those changes (not released yet). Especially, we got rid of inefficient file finding logic - notice line 122 and 142 below:

https://github.com/kubeshop/vscode-monokle/blob/63a09846c850fa6e12158b15ebeef1baad616a17/src/utils/workspace.ts#L121-L142

☝️ So for every workspace there was a watcher using globbing (L122). And one thing which could happen is when you switch branches it was triggered for multiple files. And for each file it will get resource ids (L142).

https://github.com/kubeshop/vscode-monokle/blob/63a09846c850fa6e12158b15ebeef1baad616a17/src/utils/workspace.ts#L216-L222

☝️ Now getting resource id uses `findYamlFiles` for each file.

https://github.com/kubeshop/vscode-monokle/blob/63a09846c850fa6e12158b15ebeef1baad616a17/src/utils/workspace.ts#L171-L184

☝️ And `findYamlFiles` does scanning entire workspace again 😓 🙈 Sound like a good party...

Anyways, as mentioned this logic was reworked entirely. The results with new logic:

First run:

![image](https://github.com/kubeshop/vscode-monokle/assets/1061942/49ff6be5-3559-4bc8-b562-52331862b04d)

Second run:

![image](https://github.com/kubeshop/vscode-monokle/assets/1061942/7b245c99-9620-4a11-9d75-0ea1d3ae4f89)

This looks really good. Unfortunately, found a related regression too - #70. And even though as part of the test procedure `Monokle: Validate` is run, with the regression I also checked for `rg` processes during Monokle extension initialization to also check how first repo scanning behaves:

![image](https://github.com/kubeshop/vscode-monokle/assets/1061942/e540718d-cc41-4c92-815b-ec97d6f2af0f)
![image](https://github.com/kubeshop/vscode-monokle/assets/1061942/581c58a5-0947-4245-8014-3cf42511b356)
![image](https://github.com/kubeshop/vscode-monokle/assets/1061942/4c6d4648-8baa-4620-a591-b670fb13d692)
![image](https://github.com/kubeshop/vscode-monokle/assets/1061942/ac9d3f5b-b984-4120-8c24-2071f7035ebb)

Still no `rg` party which is good 👍 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
