### PR TITLE
fix: handle config fetching error during validator creation

### DIFF
--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -285,9 +285,15 @@ async function getValidatorInstance() {
   const {MonokleValidator, ResourceParser, SchemaLoader, RemotePluginLoader, DisabledFixer, AnnotationSuppressor, FingerprintSuppressor} = await import('@monokle/validation');
   const {fetchOriginConfig} = await import('@monokle/synchronizer');
 
-  const originConfig = await fetchOriginConfig(globals.origin);
+  let originConfig = undefined;
+  try {
+    originConfig = await fetchOriginConfig(globals.origin);
+  } catch (err) {
+    logger.error('Failed to fetch origin config during validator creation', err);
+  }
+
   const parser = new ResourceParser();
-  const loader = new SchemaLoader(originConfig.schemasOrigin || undefined);
+  const loader = new SchemaLoader(originConfig?.schemasOrigin || undefined);
   const validator = new MonokleValidator({
     loader: new RemotePluginLoader(),
     parser,


### PR DESCRIPTION
This PR fixes error when validator was not able to initialize due to config fetching error.

## Changes

- None.

## Fixes

- As above.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
