### PR TITLE
Fix validation highlights and SARIF output file error

### DIFF
--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -1,7 +1,9 @@
-import { validateFolder } from '../utils/validation';
+import { Uri, workspace } from 'vscode';
+import { getValidationResultPath, validateFolder } from '../utils/validation';
 import { getWorkspaceFolders } from '../utils/workspace';
 import { canRun } from '../utils/commands';
 import { trackEvent } from '../utils/telemetry';
+import logger from '../utils/logger';
 import type { RuntimeContext } from '../utils/runtime-context';
 
 export function getValidateCommand(context: RuntimeContext) {
@@ -29,6 +31,20 @@ export function getValidateCommand(context: RuntimeContext) {
       rootCount: roots.length,
     });
 
-    return context.sarifWatcher.replace(resultFiles);
+    // Always use all existing result files for active workspaces.
+    const validResultFiles = (await Promise.all(roots.map(async (root) => {
+      const resultFile = Uri.file(getValidationResultPath(root.id));
+      try {
+        await workspace.fs.stat(resultFile);
+        return resultFile;
+      } catch (err: any) {
+        logger.warn(`No SARIF result file for ${root.id} in ${resultFile.fsPath}`, err);
+        return null;
+      }
+    }))).filter(Boolean);
+
+    logger.log('Validate results - by workspace; from validateFn:', validResultFiles, resultFiles);
+
+    return context.sarifWatcher.replace(validResultFiles);
   };
 }

--- a/src/utils/file-parser.ts
+++ b/src/utils/file-parser.ts
@@ -2,6 +2,7 @@ import { RelativePattern, TextDocument, Uri, workspace } from 'vscode';
 import { generateId } from './helpers';
 import { basename } from 'path';
 import { extractK8sResources } from './parser';
+import logger from './logger';
 
 export type File = {
   id: string;
@@ -23,6 +24,8 @@ const resourcePerFileCache = new Map<string, string>(); // <file path, resource 
 export async function getResourcesFromFolder(folderPath: string): Promise<Resource[]> {
   const resourceFiles = await findYamlFiles(folderPath);
   const dirtyFiles = workspace.textDocuments.filter(document => document.isDirty);
+
+  logger.log('getResourcesFromFolder - resources; dirtyFiles:', resourceFiles, dirtyFiles);
 
   return convertFilesToK8sResources(resourceFiles, dirtyFiles);
 }

--- a/src/utils/policy-puller.ts
+++ b/src/utils/policy-puller.ts
@@ -107,7 +107,7 @@ export class PolicyPuller {
 
   private getPolicyData(root: Folder) {
     return pRetry(async (attempt) => {
-      if (attempt === 3) {
+      if (attempt === 2) {
         await globals.forceRefreshToken();
       }
 
@@ -118,7 +118,7 @@ export class PolicyPuller {
 
       return policy;
     }, {
-      retries: 3,
+      retries: 1,
       factor: 1.2,
       minTimeout: 100,
       maxTimeout: 250,

--- a/src/utils/sarif-watcher.ts
+++ b/src/utils/sarif-watcher.ts
@@ -5,7 +5,7 @@ export class SarifWatcher {
   private _uris: Uri[] = [];
 
   async add(uri: Uri) {
-    const index = this._uris.findIndex(u => u.path === uri.path);
+    const index = this._uris.findIndex(u => u.toString() === uri.toString());
 
     if (index === -1) {
       const sarifApi = await this.getSarifApi();
@@ -16,7 +16,7 @@ export class SarifWatcher {
 
   async addMany(uris: Uri[]) {
     const sarifApi = await this.getSarifApi();
-    const added = uris.filter(u => !this._uris.find(u2 => u2.path === u.path));
+    const added = uris.filter(u => !this._uris.find(u2 => u2.toString() === u.toString()));
 
     this._uris = [...this._uris, ...added];
 
@@ -26,7 +26,7 @@ export class SarifWatcher {
   }
 
   async remove(uri: Uri) {
-    const index = this._uris.findIndex(u => u.path === uri.path);
+    const index = this._uris.findIndex(u => u.toString() === uri.toString());
 
     if (index !== -1) {
       const sarifApi = await this.getSarifApi();
@@ -36,8 +36,8 @@ export class SarifWatcher {
   }
 
   async replace(uris: Uri[]) {
-    const removed = this._uris.filter(u => !uris.find(u2 => u2.path === u.path));
-    const added = uris.filter(u => !this._uris.find(u2 => u2.path === u.path));
+    const removed = this._uris.filter(u => !uris.find(u2 => u2.toString() === u.toString()));
+    const added = uris.filter(u => !this._uris.find(u2 => u2.toString() === u.toString()));
     const sarifApi = await this.getSarifApi();
 
     this._uris = [...uris];


### PR DESCRIPTION
This PR fixes 2 issues:

- When `Monokle: Validation` command is run with unsaved files (`onSave` run configuration), it will validate a file reading it's content from fs, resulting in using file old content. This makes highlighting to be misplaced. It is fixed by checking for dirty files (and using it's contents) when reading workspace manifests - https://github.com/kubeshop/vscode-monokle/pull/72/commits/2d716c644b5d9e43419f6fcfeea6644beb35fa7b. This issue was less visible now, with run `onType` being default.
- Sometimes SARIF viewer will give an error about not able to read SARIF output file (one generated by validation process). At some point there was a logic removing unneeded result files and I thought this may be connected - SARIF reading non-existent file, but it look like we got rid of that 🤔 I was not able to reproduce it, but I added some additional checks to how result files are handled, to make sure we always load result files for all existing workspaces and that such file exists - https://github.com/kubeshop/vscode-monokle/pull/72/commits/88a05987169b6d7bcc3cb49b0a068bf41086c9eb.
- Tweaked number of retires when querying for policy because it doesn't seem to make sense to run it 4 times in a row. It just delayed a fallback to local policy (when e.g. no remote project exists) making the transition after logging in quite long.

## Changes

- As above.

## Fixes

- As above.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
