### PR TITLE
Use resource guess when extracting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@types/vscode": "^1.79.0",
         "@typescript-eslint/eslint-plugin": "^5.59.8",
         "@typescript-eslint/parser": "^5.59.8",
-        "@vscode/test-electron": "^2.3.2",
+        "@vscode/test-electron": "^2.3.8",
         "c8": "^8.0.0",
         "concurrently": "^8.2.0",
         "esbuild": "^0.18.11",
@@ -1455,15 +1455,15 @@
       }
     },
     "node_modules/@vscode/test-electron": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.3.3.tgz",
-      "integrity": "sha512-hgXCkDP0ibboF1K6seqQYyHAzCURgTwHS/6QU7slhwznDLwsRwg9bhfw1CZdyUEw8vvCmlrKWnd7BlQnI0BC4w==",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.3.8.tgz",
+      "integrity": "sha512-b4aZZsBKtMGdDljAsOPObnAi7+VWIaYl3ylCz1jTs+oV6BZ4TNHcVNC3xUn0azPeszBmwSBDQYfFESIaUQnrOg==",
       "dev": true,
       "dependencies": {
         "http-proxy-agent": "^4.0.1",
         "https-proxy-agent": "^5.0.0",
         "jszip": "^3.10.1",
-        "semver": "^7.3.8"
+        "semver": "^7.5.2"
       },
       "engines": {
         "node": ">=16"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,9 @@
       "name": "monokle",
       "version": "0.6.5",
       "dependencies": {
-        "@monokle/parser": "^0.2.0",
+        "@monokle/parser": "^0.3.0",
         "@monokle/synchronizer": "^0.12.5",
-        "@monokle/validation": "^0.31.7",
+        "@monokle/validation": "^0.31.8",
         "@segment/analytics-node": "^1.1.0",
         "normalize-url": "^4.5.1",
         "p-debounce": "^2.1.0",
@@ -820,9 +820,9 @@
       }
     },
     "node_modules/@monokle/parser": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@monokle/parser/-/parser-0.2.0.tgz",
-      "integrity": "sha512-gcCWcfOUqTubwi9mJlrOb4X5NW5B6N4/lCR7oIh5pDL75rQUfuHbSbx+BkymZnrGgNNwGX9LMGukdW8A9Y5TMQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@monokle/parser/-/parser-0.3.0.tgz",
+      "integrity": "sha512-henlNWNCLp4ZTqTsW6LC5hpxTdYz+5gTzBqkfND6zFPxkdIimK7sDLSoJQQrx5L8SLoa3AEbmJDg1EjfPIQqsg==",
       "dependencies": {
         "lodash": "4.17.21",
         "path-browserify": "^1.0.1",
@@ -879,9 +879,9 @@
       "integrity": "sha512-GGhl30a1WImxfxWg9Ys7MY1VQi2NU2iCH+gf4kKGZxS6nqAkgU4G1kTTYnxQzGNoM4Zbabh5aRxINsckIV5a+g=="
     },
     "node_modules/@monokle/validation": {
-      "version": "0.31.7",
-      "resolved": "https://registry.npmjs.org/@monokle/validation/-/validation-0.31.7.tgz",
-      "integrity": "sha512-dQVv7G6B80UMkAQc2d8+NTYq6FsfsJnM9rBI0VxJnpF01jLf+uAYHLjT0CrgJVp/Q7Q5hdUeoDPM9amtS6B7GQ==",
+      "version": "0.31.8",
+      "resolved": "https://registry.npmjs.org/@monokle/validation/-/validation-0.31.8.tgz",
+      "integrity": "sha512-+isI8coZeHV5wA1c0DmMuyRuEJvuCa/uJZC+6bP9OW0oNK26QN2WD8x5+VX/LnnzoNu0QQYpSw1leg5huPl32A==",
       "dependencies": {
         "@monokle/types": "*",
         "@open-policy-agent/opa-wasm": "1.8.0",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "@types/vscode": "^1.79.0",
     "@typescript-eslint/eslint-plugin": "^5.59.8",
     "@typescript-eslint/parser": "^5.59.8",
-    "@vscode/test-electron": "^2.3.2",
+    "@vscode/test-electron": "^2.3.8",
     "c8": "^8.0.0",
     "concurrently": "^8.2.0",
     "esbuild": "^0.18.11",

--- a/package.json
+++ b/package.json
@@ -172,9 +172,9 @@
     "typescript": "^5.1.3"
   },
   "dependencies": {
-    "@monokle/parser": "^0.2.0",
+    "@monokle/parser": "^0.3.0",
     "@monokle/synchronizer": "^0.12.5",
-    "@monokle/validation": "^0.31.7",
+    "@monokle/validation": "^0.31.8",
     "@segment/analytics-node": "^1.1.0",
     "normalize-url": "^4.5.1",
     "p-debounce": "^2.1.0",

--- a/src/utils/parser.ts
+++ b/src/utils/parser.ts
@@ -1,4 +1,4 @@
 export async function extractK8sResources(files: any[]) {
   const { extractK8sResources: extract } = await import('@monokle/parser');
-  return extract(files, false);
+  return extract(files, false, true);
 }


### PR DESCRIPTION
This PR uses resource guess to show yaml syntax errors.

This waits for https://github.com/kubeshop/monokle-core/pull/585 and needs to `core/parser` and `core/validation` to be bumped.

![monokle 20231213-1](https://github.com/kubeshop/vscode-monokle/assets/1061942/5a56bd8e-df6f-4f40-9769-82296634c292)

## Changes

- None.

## Fixes

- As above.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
