### PR TITLE
Fix SRCROOT for SARIF output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@monokle/parser": "^0.3.0",
         "@monokle/synchronizer": "^0.12.5",
-        "@monokle/validation": "^0.31.8",
+        "@monokle/validation": "^0.32.0",
         "@segment/analytics-node": "^1.1.0",
         "normalize-url": "^4.5.1",
         "p-debounce": "^2.1.0",
@@ -879,9 +879,9 @@
       "integrity": "sha512-GGhl30a1WImxfxWg9Ys7MY1VQi2NU2iCH+gf4kKGZxS6nqAkgU4G1kTTYnxQzGNoM4Zbabh5aRxINsckIV5a+g=="
     },
     "node_modules/@monokle/validation": {
-      "version": "0.31.8",
-      "resolved": "https://registry.npmjs.org/@monokle/validation/-/validation-0.31.8.tgz",
-      "integrity": "sha512-+isI8coZeHV5wA1c0DmMuyRuEJvuCa/uJZC+6bP9OW0oNK26QN2WD8x5+VX/LnnzoNu0QQYpSw1leg5huPl32A==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@monokle/validation/-/validation-0.32.0.tgz",
+      "integrity": "sha512-E22CJl64n7isG0aEoGGmoWEndKWgVWpoCMrmU6TsYccvF0W0E98LgiHxTu8iff6KzdBaWx+BDd2dQD6O0rMJYg==",
       "dependencies": {
         "@monokle/types": "*",
         "@open-policy-agent/opa-wasm": "1.8.0",

--- a/package.json
+++ b/package.json
@@ -174,7 +174,7 @@
   "dependencies": {
     "@monokle/parser": "^0.3.0",
     "@monokle/synchronizer": "^0.12.5",
-    "@monokle/validation": "^0.31.8",
+    "@monokle/validation": "^0.32.0",
     "@segment/analytics-node": "^1.1.0",
     "normalize-url": "^4.5.1",
     "p-debounce": "^2.1.0",

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -142,11 +142,26 @@ export async function validateResourcesFromFolder(resources: Resource[], root: F
     };
   }
 
-  const result = await validator.validate({
-    resources: resourcesRelative,
-    incremental: incrementalParam,
-    srcroot: root.uri.toString(),
-  });
+  let result = null;
+  try {
+    result = await validator.validate({
+      resources: resourcesRelative,
+      incremental: incrementalParam,
+      srcroot: root.uri.toString(),
+    });
+  } catch (err: any) {
+    logger.error('Validation failed', err);
+
+    trackEvent('workspace/validate', {
+      status: 'failure',
+      resourceCount: resourcesRelative.length,
+      configurationType: workspaceConfig.type,
+      isValidConfiguration: workspaceConfig.isValid,
+      error: err.message,
+    });
+
+    return null;
+  }
 
   logger.log(root.name, 'result', result);
 

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -134,6 +134,7 @@ export async function validateResourcesFromFolder(resources: Resource[], root: F
   const validator = await getValidator(root.id, workspaceConfig.config);
 
   logger.log(root.name, 'validator', validator);
+  logger.log(root, resources, resourcesRelative);
 
   let incrementalParam: {resourceIds: string[]} | undefined = undefined;
   if (incremental) {

--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -165,7 +165,7 @@ async function runFileWithContentValidation(file: Uri, content: string,  workspa
   const configChanged = await isConfigFileAffected(workspaceFolders, [file]);
 
   const previousFileResourceId = getFileCacheId(file.fsPath);
-  const resources = await getResourcesFromFileAndContent(file.path, content);
+  const resources = await getResourcesFromFileAndContent(file.fsPath, content);
   const currentFileResourceId = getFileCacheId(file.fsPath);
 
   logger.log(
@@ -199,7 +199,7 @@ async function runFilesValidation(files: readonly Uri[], workspaceFolders: Folde
 
   const resources = (await Promise.all(files.map(async (file) => {
     const previousFileResourceId = getFileCacheId(file.fsPath);
-    const resources = await getResourcesFromFile(file.path);
+    const resources = await getResourcesFromFile(file.fsPath);
     const currentFileResourceId = getFileCacheId(file.fsPath);
 
     useIncremental = useIncremental && previousFileResourceId === currentFileResourceId;


### PR DESCRIPTION
This PR changes how validation is run with `srcroot` pointing to wrokspace folder and then using relative paths for resources.

Also added try catch for validation, because I noticed for specific directory (admission-controller with CRDs) it was failing. I'll report an issue afterwards.

_Testing on Windows in progress..._

## Changes

- As above.

## Fixes

- As above.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
