### PR TITLE
Add client data to synchronizer instances

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.8.1",
       "dependencies": {
         "@monokle/parser": "^0.3.2",
-        "@monokle/synchronizer": "^0.12.5",
+        "@monokle/synchronizer": "^0.13.0",
         "@monokle/validation": "^0.32.0",
         "@segment/analytics-node": "^1.1.0",
         "normalize-url": "^4.5.1",
@@ -838,9 +838,9 @@
       }
     },
     "node_modules/@monokle/synchronizer": {
-      "version": "0.12.5",
-      "resolved": "https://registry.npmjs.org/@monokle/synchronizer/-/synchronizer-0.12.5.tgz",
-      "integrity": "sha512-NBD9VLrIiuihevElowmG9tikIHQZV6HuAMXgC6TmINWyTV08ZjnnsZLDC+4VHsKNnE3KvIuJ37IPAVgAKaAqjQ==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@monokle/synchronizer/-/synchronizer-0.13.0.tgz",
+      "integrity": "sha512-rTfzoDC4A3mLkxYnpUeYHzLK2cIjugBarxJ3+Dyq8MgSbXcPmW5GaxbqTJRZX2KEPlj2ozJHRmXAsoxcOpwQVA==",
       "dependencies": {
         "@monokle/types": "*",
         "env-paths": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -173,7 +173,7 @@
   },
   "dependencies": {
     "@monokle/parser": "^0.3.2",
-    "@monokle/synchronizer": "^0.12.5",
+    "@monokle/synchronizer": "^0.13.0",
     "@monokle/validation": "^0.32.0",
     "@segment/analytics-node": "^1.1.0",
     "normalize-url": "^4.5.1",

--- a/src/client-config.ts
+++ b/src/client-config.ts
@@ -1,0 +1,18 @@
+import { type, release } from 'os';
+import { readFileSync } from 'fs';
+import { env } from 'vscode';
+
+const CLIENT_NAME = 'Monokle CLI';
+
+export function getClientConfig() {
+	const pkg = JSON.parse(readFileSync(`${__dirname}/../package.json`, 'utf8'));
+
+	return {
+		name: CLIENT_NAME,
+		version: pkg.version,
+		os: `${type()} ${release()}`,
+		additionalData: {
+			machineId: env.machineId,
+		}
+	};
+}

--- a/src/client-config.ts
+++ b/src/client-config.ts
@@ -2,7 +2,7 @@ import { type, release } from 'os';
 import { readFileSync } from 'fs';
 import { env } from 'vscode';
 
-const CLIENT_NAME = 'Monokle CLI';
+const CLIENT_NAME = 'Monokle VSCode';
 
 export function getClientConfig() {
 	const pkg = JSON.parse(readFileSync(`${__dirname}/../package.json`, 'utf8'));

--- a/src/client-config.ts
+++ b/src/client-config.ts
@@ -1,18 +1,18 @@
 import { type, release } from 'os';
 import { readFileSync } from 'fs';
 import { env } from 'vscode';
+import globals from './utils/globals';
 
 const CLIENT_NAME = 'Monokle VSCode';
 
 export function getClientConfig() {
 	const pkg = JSON.parse(readFileSync(`${__dirname}/../package.json`, 'utf8'));
+	const additionalData = globals.telemetryEnabled ? { machineId: env.machineId } : {};
 
 	return {
 		name: CLIENT_NAME,
 		version: pkg.version,
 		os: `${type()} ${release()}`,
-		additionalData: {
-			machineId: env.machineId,
-		}
+		additionalData,
 	};
 }

--- a/src/utils/authentication.ts
+++ b/src/utils/authentication.ts
@@ -1,3 +1,5 @@
+import { getClientConfig } from '../client-config';
+
 export type Authenticator = Awaited<ReturnType<typeof getAuthenticator>>;
 
 export const AUTH_CLIENT_ID = 'mc-cli';
@@ -17,7 +19,7 @@ export async function getAuthenticator(origin?: string) {
   const {createMonokleAuthenticatorFromOrigin} = await import('@monokle/synchronizer');
 
   try {
-    const authenticator = await createMonokleAuthenticatorFromOrigin(AUTH_CLIENT_ID, origin);
+    const authenticator = await createMonokleAuthenticatorFromOrigin(AUTH_CLIENT_ID, getClientConfig(), origin);
     return authenticator;
   } catch (err: any) {
     // Without this entire extension can run only in local mode. Needs to be obvious to users what went wrong and how to fix.

--- a/src/utils/synchronization.ts
+++ b/src/utils/synchronization.ts
@@ -1,3 +1,5 @@
+import { getClientConfig } from '../client-config';
+
 export type Synchronizer = Awaited<ReturnType<typeof getSynchronizer>>;
 
 export async function getSynchronizer(origin?: string) {
@@ -26,7 +28,7 @@ export async function getSynchronizer(origin?: string) {
   const {createMonokleSynchronizerFromOrigin} = await import('@monokle/synchronizer');
 
   try {
-    const synchronizer = await createMonokleSynchronizerFromOrigin(origin);
+    const synchronizer = await createMonokleSynchronizerFromOrigin(getClientConfig(), origin);
     return synchronizer;
   } catch (err: any) {
     // Without this entire extension can run only in local mode. Needs to be obvious to users what went wrong and how to fix.


### PR DESCRIPTION
This PR adds client data to synchronizer instances. Part of https://github.com/kubeshop/monokle-saas/issues/1904.

Requires https://github.com/kubeshop/monokle-core/pull/593.

## Changes

- As above.

## Fixes

- None.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
