### PR TITLE
Add open panel config and quick action

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,6 +128,15 @@
           ],
           "default": "onType",
           "description": "Run validation on save (onSave) or on type (onType)"
+        },
+        "monokle.automaticallyOpenPanel": {
+          "type": "string",
+          "enum": [
+            "never",
+            "onProjectOpen"
+          ],
+          "default": "never",
+          "description": "Show 'Violations' panel automatically on project open (`onProjectOpen`) or `never` (default, requires user action to show panel)."
         }
       }
     }

--- a/src/commands/run-commands.ts
+++ b/src/commands/run-commands.ts
@@ -4,17 +4,13 @@ import type { RuntimeContext } from '../utils/runtime-context';
 
 // This is internal command (not exposed via 'package.json') to run multiple commands at once from code actions.
 export function getRunCommandsCommand(_context: RuntimeContext) {
-  return async (allCommands: Command[], after: () => Promise<void>) => {
+  return async (allCommands: Command[]) => {
     if (!canRun()) {
       return;
     }
 
     for (const command of allCommands) {
         await commands.executeCommand(command.command, ...(command.arguments || []));
-    }
-
-    if (after) {
-      await after();
     }
   };
 }

--- a/src/commands/run-commands.ts
+++ b/src/commands/run-commands.ts
@@ -1,0 +1,16 @@
+import { canRun } from '../utils/commands';
+import { Command, commands } from 'vscode';
+import type { RuntimeContext } from '../utils/runtime-context';
+
+// This is internal command (not exposed via 'package.json') to run multiple commands at once from code actions.
+export function getRunCommandsCommand(_context: RuntimeContext) {
+  return async (allCommands: Command[]) => {
+    if (!canRun()) {
+      return;
+    }
+
+    for (const command of allCommands) {
+        await commands.executeCommand(command.command, ...(command.arguments || []));
+    }
+  };
+}

--- a/src/commands/run-commands.ts
+++ b/src/commands/run-commands.ts
@@ -4,13 +4,17 @@ import type { RuntimeContext } from '../utils/runtime-context';
 
 // This is internal command (not exposed via 'package.json') to run multiple commands at once from code actions.
 export function getRunCommandsCommand(_context: RuntimeContext) {
-  return async (allCommands: Command[]) => {
+  return async (allCommands: Command[], after: () => Promise<void>) => {
     if (!canRun()) {
       return;
     }
 
     for (const command of allCommands) {
         await commands.executeCommand(command.command, ...(command.arguments || []));
+    }
+
+    if (after) {
+      await after();
     }
   };
 }

--- a/src/commands/show-panel.ts
+++ b/src/commands/show-panel.ts
@@ -3,7 +3,7 @@ import { canRun } from '../utils/commands';
 import { trackEvent } from '../utils/telemetry';
 
 export function getShowPanelCommand() {
-  return async () => {
+  return async (resultId: any) => {
     if (!canRun()) {
       return null;
     }
@@ -18,7 +18,7 @@ export function getShowPanelCommand() {
       await sarifExtension.activate();
     }
 
-    await commands.executeCommand('monokle-sarif.showPanel');
+    await commands.executeCommand('monokle-sarif.showPanel', [resultId]);
 
     trackEvent('command/show_panel', {
       status: 'success'

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -38,7 +38,8 @@ export const COMMANDS = {
   SYNCHRONIZE: 'monokle.synchronize',
   WATCH: 'monokle.watch',
   TRACK: 'monokle.track',
-  RAISE_AUTHENTICATION_ERROR: 'monokle.raiseAuthenticationError'
+  RAISE_AUTHENTICATION_ERROR: 'monokle.raiseAuthenticationError',
+  RUN_COMMANDS: 'monokle.runCommands',
 };
 
 export const COMMAND_NAMES = {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -17,6 +17,7 @@ export const SETTINGS = {
   ORIGIN: 'origin',
   PROJECT: 'project',
   RUN: 'run',
+  AUTOMATICALLY_OPEN_PANEL: 'automaticallyOpenPanel',
   ENABLED_PATH: 'monokle.enabled',
   CONFIGURATION_PATH_PATH: 'monokle.configurationPath',
   VERBOSE_PATH: 'monokle.verbose',
@@ -24,6 +25,7 @@ export const SETTINGS = {
   ORIGIN_PATH: 'monokle.origin',
   PROJECT_PATH: 'monokle.project',
   RUN_PATH: 'monokle.run',
+  AUTOMATICALLY_OPEN_PANEL_PATH: 'monokle.automaticallyOpenPanel',
 };
 
 export const COMMANDS = {

--- a/src/core/code-actions/base-code-actions-provider.ts
+++ b/src/core/code-actions/base-code-actions-provider.ts
@@ -4,6 +4,7 @@ import { CodeAction, CodeActionContext, CodeActionKind, CodeActionProvider, Text
 import { ValidationResult, ValidationRule } from './../../utils/validation';
 
 export type ValidationResultExtended = ValidationResult & {
+  _id: [string, number, number];
   _rule: ValidationRule;
 };
 

--- a/src/core/code-actions/index.ts
+++ b/src/core/code-actions/index.ts
@@ -1,2 +1,3 @@
 export * from './annotation-suppressions-code-actions-provider';
 export * from './fix-code-actions-provider';
+export * from './show-details-code-actions-provider';

--- a/src/core/code-actions/show-details-code-actions-provider.ts
+++ b/src/core/code-actions/show-details-code-actions-provider.ts
@@ -1,0 +1,62 @@
+import { CodeAction, CodeActionKind, TextDocument, Range, languages } from 'vscode';
+import { BaseCodeActionsProvider, CodeActionContextExtended, DiagnosticExtended } from './base-code-actions-provider';
+import { COMMANDS } from '../../constants';
+
+class ShowDetailsCodeActionsProvider extends BaseCodeActionsProvider<ShowDetailsCodeAction> {
+  public async provideCodeActions(_document: TextDocument, _range: Range, context: CodeActionContextExtended) {
+    const monokleDiagnostics = this.getMonokleDiagnostics(context);
+
+    if (!monokleDiagnostics.length) {
+      [];
+    }
+
+    if (monokleDiagnostics.length === 1) {
+      return [new ShowSingleDetailsCodeAction(monokleDiagnostics[0])];
+    }
+
+    return [new ShowAllDetailsCodeAction(monokleDiagnostics)];
+  }
+
+  public async resolveCodeAction(codeAction: ShowDetailsCodeAction) {
+    const commands = [{
+      command: COMMANDS.SHOW_PANEL,
+      title: 'Show panel',
+    }, {
+      command: COMMANDS.TRACK,
+      title: 'Track',
+      arguments: ['code_action/show_details', {status: 'success'}]
+    }];
+
+    codeAction.command = {
+      command: COMMANDS.RUN_COMMANDS,
+      title: 'Run commands',
+      arguments: commands
+    };
+
+    return codeAction;
+  }
+}
+
+class ShowDetailsCodeAction extends CodeAction {}
+
+class ShowSingleDetailsCodeAction extends ShowDetailsCodeAction {
+  constructor(diagnostic: DiagnosticExtended) {
+    super(`Show details for "${diagnostic.result._rule.name} (${diagnostic.result._rule.id})" violation`, CodeActionKind.QuickFix);
+
+    this.diagnostics = [diagnostic];
+  }
+}
+
+class ShowAllDetailsCodeAction extends ShowDetailsCodeAction {
+  constructor(diagnostics: DiagnosticExtended[]) {
+    super(`Show details for all ${diagnostics.length} violations`, CodeActionKind.QuickFix);
+
+    this.diagnostics = diagnostics;
+  }
+}
+
+export function registerShowDetailsCodeActionsProvider() {
+  return languages.registerCodeActionsProvider({language: 'yaml'}, new ShowDetailsCodeActionsProvider(), {
+    providedCodeActionKinds: ShowDetailsCodeActionsProvider.providedCodeActionKinds
+  });
+}

--- a/src/core/code-actions/show-details-code-actions-provider.ts
+++ b/src/core/code-actions/show-details-code-actions-provider.ts
@@ -1,4 +1,4 @@
-import { CodeAction, CodeActionKind, TextDocument, Range, languages } from 'vscode';
+import { CodeAction, CodeActionKind, TextDocument, Selection, Range, languages, window } from 'vscode';
 import { BaseCodeActionsProvider, CodeActionContextExtended, DiagnosticExtended } from './base-code-actions-provider';
 import { COMMANDS } from '../../constants';
 
@@ -27,10 +27,20 @@ class ShowDetailsCodeActionsProvider extends BaseCodeActionsProvider<ShowDetails
       arguments: ['code_action/show_details', {status: 'success'}]
     }];
 
+    const afterFn = async () => {
+      const textEditor = window.activeTextEditor;
+      setTimeout(() => {
+        textEditor.selection = new Selection(
+          codeAction.diagnostics[0].range.start,
+          codeAction.diagnostics[codeAction.diagnostics.length - 1].range.end
+        );
+      }, 500);
+    };
+
     codeAction.command = {
       command: COMMANDS.RUN_COMMANDS,
       title: 'Run commands',
-      arguments: commands
+      arguments: [commands, afterFn]
     };
 
     return codeAction;
@@ -49,7 +59,7 @@ class ShowSingleDetailsCodeAction extends ShowDetailsCodeAction {
 
 class ShowAllDetailsCodeAction extends ShowDetailsCodeAction {
   constructor(diagnostics: DiagnosticExtended[]) {
-    super(`Show details for all ${diagnostics.length} violations`, CodeActionKind.QuickFix);
+    super(`Show details for these violations`, CodeActionKind.QuickFix);
 
     this.diagnostics = diagnostics;
   }

--- a/src/core/code-actions/show-details-code-actions-provider.ts
+++ b/src/core/code-actions/show-details-code-actions-provider.ts
@@ -1,4 +1,4 @@
-import { CodeAction, CodeActionKind, TextDocument, Selection, Range, languages, window } from 'vscode';
+import { CodeAction, CodeActionKind, TextDocument, Range, languages } from 'vscode';
 import { BaseCodeActionsProvider, CodeActionContextExtended, DiagnosticExtended } from './base-code-actions-provider';
 import { COMMANDS } from '../../constants';
 
@@ -21,33 +21,28 @@ class ShowDetailsCodeActionsProvider extends BaseCodeActionsProvider<ShowDetails
     const commands = [{
       command: COMMANDS.SHOW_PANEL,
       title: 'Show panel',
+      arguments: [codeAction.firstResult._id]
     }, {
       command: COMMANDS.TRACK,
       title: 'Track',
       arguments: ['code_action/show_details', {status: 'success'}]
     }];
 
-    const afterFn = async () => {
-      const textEditor = window.activeTextEditor;
-      setTimeout(() => {
-        textEditor.selection = new Selection(
-          codeAction.diagnostics[0].range.start,
-          codeAction.diagnostics[codeAction.diagnostics.length - 1].range.end
-        );
-      }, 500);
-    };
-
     codeAction.command = {
       command: COMMANDS.RUN_COMMANDS,
       title: 'Run commands',
-      arguments: [commands, afterFn]
+      arguments: [commands]
     };
 
     return codeAction;
   }
 }
 
-class ShowDetailsCodeAction extends CodeAction {}
+class ShowDetailsCodeAction extends CodeAction {
+  get firstResult() {
+    return (this.diagnostics[0] as DiagnosticExtended).result;
+  }
+}
 
 class ShowSingleDetailsCodeAction extends ShowDetailsCodeAction {
   constructor(diagnostic: DiagnosticExtended) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,7 +23,7 @@ import { trackEvent, initTelemetry, closeTelemetry } from './utils/telemetry';
 import logger from './utils/logger';
 import globals from './utils/globals';
 import { raiseError } from './utils/errors';
-import { registerAnnotationSuppressionsCodeActionsProvider, registerFixCodeActionsProvider } from './core';
+import { registerAnnotationSuppressionsCodeActionsProvider, registerFixCodeActionsProvider, registerShowDetailsCodeActionsProvider } from './core';
 import type { ExtensionContext } from 'vscode';
 
 let runtimeContext: RuntimeContext;
@@ -124,6 +124,7 @@ async function runActivation(context: ExtensionContext) {
 
   context.subscriptions.push(registerAnnotationSuppressionsCodeActionsProvider());
   context.subscriptions.push(registerFixCodeActionsProvider());
+  context.subscriptions.push(registerShowDetailsCodeActionsProvider());
 
   const configurationWatcher = workspace.onDidChangeConfiguration(async (event) => {
     if (event.affectsConfiguration(SETTINGS.ENABLED_PATH)) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,6 +12,7 @@ import { getSynchronizeCommand } from './commands/synchronize';
 import { getLogoutCommand } from './commands/logout';
 import { getTrackCommand } from './commands/track';
 import { getRaiseAuthenticationErrorCommand } from './commands/raiseAuthenticationError';
+import { getRunCommandsCommand } from './commands/run-commands';
 import { RuntimeContext } from './utils/runtime-context';
 import { SarifWatcher } from './utils/sarif-watcher';
 import { PolicyPuller } from './utils/policy-puller';
@@ -105,6 +106,7 @@ async function runActivation(context: ExtensionContext) {
   const commandWatch = commands.registerCommand(COMMANDS.WATCH, getWatchCommand(runtimeContext));
   const commandTrack = commands.registerCommand(COMMANDS.TRACK, getTrackCommand(runtimeContext));
   const commandRaiseAuthenticationError = commands.registerCommand(COMMANDS.RAISE_AUTHENTICATION_ERROR, getRaiseAuthenticationErrorCommand(runtimeContext));
+  const commandRunCommands = commands.registerCommand(COMMANDS.RUN_COMMANDS, getRunCommandsCommand(runtimeContext));
 
   context.subscriptions.push(
     commandLogin,
@@ -116,7 +118,8 @@ async function runActivation(context: ExtensionContext) {
     commandBootstrapConfiguration,
     commandDownloadPolicy,
     commandTrack,
-    commandRaiseAuthenticationError
+    commandRaiseAuthenticationError,
+    commandRunCommands
   );
 
   context.subscriptions.push(registerAnnotationSuppressionsCodeActionsProvider());

--- a/src/test/helpers/asserts.ts
+++ b/src/test/helpers/asserts.ts
@@ -42,17 +42,17 @@ export async function waitForValidationResults(workspaceFolder: Folder, timeoutM
 }
 
 
-export async function waitForCodeActionList(uri: Uri, range: Range, timeoutMs?: number): Promise<CodeAction[]> {
-  
+export async function waitForCodeActionList(uri: Uri, range: Range, expectedMinActions?: number, timeoutMs?: number,): Promise<CodeAction[]> {
+
   if(timeoutMs && timeoutMs > 0) {
     try {
       const start = Date.now();
       const codeActions = await commands.executeCommand<CodeAction[]>('vscode.executeCodeActionProvider', uri, range);
-      if(!!codeActions?.length) {
+      if(!!codeActions?.length && codeActions.length >= expectedMinActions) {
         return codeActions;
       }
       const end = Date.now();
-      return waitForCodeActionList(uri, range, timeoutMs - (end - start));
+      return waitForCodeActionList(uri, range, expectedMinActions, timeoutMs - (end - start));
     } catch (error) {
       logger.error(error.message, {uri, range}, error);
     }

--- a/src/test/run-test.ts
+++ b/src/test/run-test.ts
@@ -153,14 +153,14 @@ async function main() {
 
   // Run policies tests on single repo.
   await runSuite('./suite-policies/index', [workspaces.withConfig], { setupRemoteEnv: true });
-  
+
   // Run code-actions tests
   await runSuite('./suite-code-actions/index', [workspaces.withCodeActions], { skipResultCache: true });
 
   // Run integration-like tests on multiple, different workspaces (local config).
   await runSuite('./suite-integration/index', [workspaces.withResources, workspaces.withoutResources, workspaces.workspace], { skipResultCache: true });
   await runSuite('./suite-integration/index', [workspaces.withResources, workspaces.withoutResources, workspaces.workspace], { skipResultCache: true, validateOnSave: true });
-  
+
   // Run integration-like tests for remote config separately as it needs different setup.
   await runSuite('./suite-integration/index', [workspaces.withConfig], { setupRemoteEnv: true });
 }

--- a/src/test/run-test.ts
+++ b/src/test/run-test.ts
@@ -52,7 +52,7 @@ async function runSuite(
     // Use cp.spawn / cp.exec for custom setup
     spawnSync(
       cliPath,
-      [...args, '--install-extension', 'kubeshop.monokle-sarif@0.1.0'],
+      [...args, '--install-extension', 'kubeshop.monokle-sarif'],
       {
         encoding: 'utf-8',
         stdio: 'inherit'

--- a/src/test/suite-code-actions/fix.test.ts
+++ b/src/test/suite-code-actions/fix.test.ts
@@ -60,7 +60,7 @@ suite(`CodeActions - quick fix (${RUN_ON}): ${process.env.ROOT_PATH}`, async fun
         const range = await getRange(validationResponse);
         const document = await workspace.openTextDocument(uri);
         await vscodeWindow.showTextDocument(document);
-        const codeActions = await waitForCodeActionList(uri, range, 5000);
+        const codeActions = await waitForCodeActionList(uri, range, 2, 5000);
 
         if (!codeActions.find(({ kind, title }) => {
           return kind.value === CodeActionKind.QuickFix.value && title.includes('KBP104');

--- a/src/utils/globals.ts
+++ b/src/utils/globals.ts
@@ -71,6 +71,10 @@ class Globals {
     return workspace.getConfiguration(SETTINGS.NAMESPACE).get<string>(SETTINGS.RUN);
   }
 
+  get automaticallyOpenPanel() {
+    return workspace.getConfiguration(SETTINGS.NAMESPACE).get<string>(SETTINGS.AUTOMATICALLY_OPEN_PANEL);
+  }
+
   async setDefaultOrigin() {
     const {DEFAULT_ORIGIN} = await import('@monokle/synchronizer');
     this._defaultOrigin = DEFAULT_ORIGIN;

--- a/src/utils/telemetry.ts
+++ b/src/utils/telemetry.ts
@@ -105,6 +105,7 @@ export type EventMap = {
   // Code actions tracking.
   'code_action/annotation_suppression': BaseEvent & {[key: string]: string | number | boolean};
   'code_action/fix': BaseEvent & {[key: string]: string | number | boolean};
+  'code_action/show_details': BaseEvent;
 };
 
 function getAppVersion(): string {


### PR DESCRIPTION
This PR adds config to change when Violations panel is shown, fixes #6. Also fixes #2.

It also introduces code action to show panel from code actions panel.

Needs https://github.com/kubeshop/vscode-sarif/pull/6 and https://github.com/kubeshop/vscode-sarif/pull/7 to be merged first.

![monokle 20240130-1](https://github.com/kubeshop/vscode-monokle/assets/1061942/0f0aaef7-4fc6-4152-aa73-6fa3831b196f)

## Changes

- As above.

## Fixes

- None.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
